### PR TITLE
Fix numpy type compatibility issue

### DIFF
--- a/python/rainbow/geometry/surface_mesh.py
+++ b/python/rainbow/geometry/surface_mesh.py
@@ -101,7 +101,7 @@ def profile_sweep(profile, slices):
     F = 2 * J * (N - 2)  # Total number of triangle faces
 
     V = np.zeros((K, 3), dtype=np.float64)
-    T = np.zeros((F, 3), dtype=np.int)
+    T = np.zeros((F, 3), dtype=int)
 
     # Make a 2D grid of vertices by sweeping profile around y-axis
     dtheta = 2.0 * np.pi / J  # The angle of each slice
@@ -253,7 +253,7 @@ def create_cuboid(p0, p1, p2, p3, p4, p5, p6, p7):
     :return:
     """
     V = np.zeros((8, 3), dtype=np.float64)
-    T = np.zeros((12, 3), dtype=np.int)
+    T = np.zeros((12, 3), dtype=int)
 
     V[0, :] = p0
     V[1, :] = p1
@@ -342,7 +342,7 @@ def create_convex_hull(points):
     N = len(H.points)  # Number of vertices
     K = len(H.vertices)  # Number of triangles
     V = np.zeros((N, 3), dtype=np.float64)
-    T = np.zeros((K, 3), dtype=np.int)
+    T = np.zeros((K, 3), dtype=int)
     for idx, p in enumerate(H.points):
         V[idx, :] = p
     for idx, v in enumerate(H.vertices):

--- a/python/rainbow/simulators/prox_rigid_bodies/gauss_seidel.py
+++ b/python/rainbow/simulators/prox_rigid_bodies/gauss_seidel.py
@@ -210,7 +210,7 @@ def solve(J, WJT, b, mu, friction_solver, engine, stats, debug_on, prefix):
         stats[prefix + "lambda"] = np.zeros(
             [engine.params.max_iterations] + list(b.shape), dtype=np.float64
         )
-        stats[prefix + "reject"] = np.zeros(engine.params.max_iterations, dtype=np.bool)
+        stats[prefix + "reject"] = np.zeros(engine.params.max_iterations, dtype=bool)
         stats[prefix + "exitcode"] = 0
         stats[prefix + "iterations"] = engine.params.max_iterations
         timer.start()


### PR DESCRIPTION
The both np.int and np.bool data types are deprecated from numpy 1.20.0, more information refers to https://numpy.org/devdocs/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated