### PR TITLE
Speedup contact point reduction phase

### DIFF
--- a/python/rainbow/simulators/prox_soft_bodies/collision_detection.py
+++ b/python/rainbow/simulators/prox_soft_bodies/collision_detection.py
@@ -283,8 +283,9 @@ def _contact_determination(overlaps, engine, stats, debug_on):
         stats["contact_determination"] = contact_determination_timer.elapsed
     return stats
 
+
 def _cp_unique_id(cp) -> tuple:
-    """ This function returns a unique id for a contact point.
+    """ This function returns a unique id for a ContactPoint instance.
     Args:
         cp (ContactPoint): A instance of the ContactPoint
 
@@ -293,7 +294,8 @@ def _cp_unique_id(cp) -> tuple:
     """
     return (cp.bodyA, cp.bodyB, tuple(cp.p))
 
-def _optimize_contact_reduction(engine, stats, debug_on):
+
+def _contact_reduction(engine, stats, debug_on):
     """ During contact point computation it may happen that different colliding triangles of one body results
     in the same contact point locations wrt to the other signed distance field of the other body. Imagine a spiky
     polygonal cone pointing into a spherical shape. Here all triangles of the spike will result in the same
@@ -311,6 +313,7 @@ def _optimize_contact_reduction(engine, stats, debug_on):
     Returns:
         dict: A dictionary with profiling and timing measurements.
     """
+    reduction_timer = None
     if debug_on:
         reduction_timer = Timer("contact_point_reduction", 8)
         reduction_timer.start()
@@ -330,46 +333,6 @@ def _optimize_contact_reduction(engine, stats, debug_on):
         reduction_timer.end()
         stats["contact_point_reduction"] = reduction_timer.elapsed
 
-    return stats
-
-def _contact_reduction(engine, stats, debug_on):
-    """
-    During contact point computation it may happen that different colliding triangles of one body results
-    in the same contact point locations wrt to the other signed distance field of the other body. Imagine a spiky
-    polygonal cone pointing into a spherical shape. Here all triangles of the spike will result in the same
-    contact point at the spiky tip. If the spiky polygonal cone has N triangle faces on the spike then we
-     will have N redundant contact points. This redundancy is usually bad for other numerical sub-routines for
-    computing impacts or contact forces. Hence, the purpose of this step is to eliminate redundant
-    contact point information. One may think of this as a kind of post-filtering process to clean up the
-     contact point information.
-
-     :param engine:      The current engine instance we are working with.
-     :param stats:       A dictionary where to add more profiling and timing measurements.
-     :param debug_on:    Boolean flag for toggling debug (aka profiling) info on and off.
-     :return:            A dictionary with profiling and timing measurements.
-    """
-    if engine.params.speedup:
-        return _optimize_contact_reduction(engine, stats, debug_on)
-    
-    reduction_timer = None
-    if debug_on:
-        reduction_timer = Timer("contact_point_reduction", 8)
-        reduction_timer.start()
-    # TODO 2020-09-07 Kristian: This brute force implementation can be implemented better
-    reduced_list = []
-    for cp1 in engine.contact_points:
-        unique = True
-        for cp2 in reduced_list:
-            if {cp1.bodyA, cp1.bodyB} == {cp2.bodyA, cp2.bodyB} and (
-                cp1.p == cp2.p
-            ).all():
-                unique = False
-        if unique:
-            reduced_list.append(cp1)
-    engine.contact_points = reduced_list
-    if debug_on:
-        reduction_timer.end()
-        stats["contact_point_reduction"] = reduction_timer.elapsed
     return stats
 
 

--- a/python/rainbow/simulators/prox_soft_bodies/types.py
+++ b/python/rainbow/simulators/prox_soft_bodies/types.py
@@ -252,6 +252,7 @@ class Parameters:
             0.1  # Any geometry within this distance generates a contact point.
         )
         self.resolution = 64  # The number of grid cells along each axis in the signed distance fields.
+        self.speedup = True
 
 
 class Engine:

--- a/python/rainbow/simulators/prox_soft_bodies/types.py
+++ b/python/rainbow/simulators/prox_soft_bodies/types.py
@@ -252,7 +252,6 @@ class Parameters:
             0.1  # Any geometry within this distance generates a contact point.
         )
         self.resolution = 64  # The number of grid cells along each axis in the signed distance fields.
-        self.speedup = True
 
 
 class Engine:


### PR DESCRIPTION
We've transitioned from a double loop to a single loop in the contact point reduction phase, leading to enhanced acceleration over the old method. Detailed comparisons are provided below:

the below figure compares the performance of both the old and the improved versions of the contact point reduction phase for each frame in a given simulation.
![profile_contact_points_reduction_frame](https://github.com/diku-dk/RAINBOW/assets/7382116/c76fb8e9-8d95-4d57-980e-39485dca0b49)

This figure shows an overview of the total simulation time and the contact point reduction phase's duration, showcasing results with an increasing number of tetrahedrons between the old and improved versions.
![profile_contact_points_reduction_num_tets](https://github.com/diku-dk/RAINBOW/assets/7382116/9360caaa-f015-4c2c-a4f0-e7f5678a154d)


