### PR TITLE
Numba cuda for contact point computing

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -33,6 +33,7 @@ jobs:
             conda install pyparsing
             conda install -c anaconda ipython_genutils 
             conda install -c conda-forge meshplot
+            conda install numba
             coverage run  -m unittest python/unit_tests/test_*.py
             coverage report
       - name: Format the code

--- a/python/rainbow/cuda/collision_detection/compute_contacts.py
+++ b/python/rainbow/cuda/collision_detection/compute_contacts.py
@@ -1,0 +1,206 @@
+import numpy as np
+from numba import cuda, float64
+
+import rainbow.cuda.math.vec as Vector
+import rainbow.cuda.math.matrix as Matrix
+import rainbow.cuda.math.linalg as LinAlg
+import rainbow.cuda.geometry.barycentric as BC
+import rainbow.cuda.geometry.grid3 as Grid3
+
+
+@cuda.jit(device=True)
+def xform_triangle_to_model_space_device(P, X, X0, P0):
+    Matrix.mat33_zero(P0)
+
+    w0 = cuda.local.array(4, dtype=float64)
+    w1 = cuda.local.array(4, dtype=float64)
+    w2 = cuda.local.array(4, dtype=float64)
+
+    BC.compute_barycentric_tetrahedron_device(X[0], X[1], X[2], X[3], P[0], w0)
+    BC.compute_barycentric_tetrahedron_device(X[0], X[1], X[2], X[3], P[1], w1)
+    BC.compute_barycentric_tetrahedron_device(X[0], X[1], X[2], X[3], P[2], w2)
+
+    t = cuda.local.array((3, 4), dtype=float64)
+    Matrix.mat43_T(X0, t)
+
+    Matrix.mat34_dot_vec4(t, w0, P0[0])
+    Matrix.mat34_dot_vec4(t, w1, P0[1])
+    Matrix.mat34_dot_vec4(t, w2, P0[2])
+
+
+@cuda.jit(device=True)
+def compute_omegaB_device(p, X0B, omegaB):
+    BC.compute_barycentric_tetrahedron_device(X0B[0], X0B[1], X0B[2], X0B[3], p, omegaB)
+
+
+@cuda.jit(device=True)
+def compute_omegaA_device(p, XA, omegaA):
+    BC.compute_barycentric_tetrahedron_device(XA[0], XA[1], XA[2], XA[3], p, omegaA)
+
+
+@cuda.jit(device=True)
+def compute_p_device(p, XB, omegaB, result):
+    t = cuda.local.array((3, 4), dtype=float64)
+    Matrix.mat43_T(XB, t)
+    Matrix.mat34_dot_vec4(t, omegaB, result)
+
+
+@cuda.jit(device=True)
+def compute_n_device(n, XB, X0B, result):
+    D = cuda.local.array((3,3), dtype=float64)
+    D0 = cuda.local.array((3, 3), dtype=float64)
+    for i in range(3):
+        for j in range(3):
+            D[i, j] = XB[i, j] - XB[3, j]
+            D0[i, j] = X0B[i, j] - X0B[3, j]
+    solve_res = cuda.local.array(3, dtype=float64)
+    LinAlg.cramer_solver(D0, n, solve_res)
+    Matrix.mat33_dot_vec3(D, solve_res, result)
+
+
+@cuda.jit(device=True)
+def compute_contacts_device(idx_triA, idx_triB, A_owners, B_owners, A_x, B_x, B_x0, A_surface, A_T, B_T,  B_grid_min_coord, B_grid_max_coord, B_grid_spacing, B_grid_I, B_grid_J, B_grid_K, B_grid_values, max_iteration, optimization_tolerance, envelope, boundary, result):
+        idx_tetA = A_owners[idx_triA][0]
+        idx_tetB = B_owners[idx_triB][0]
+
+        P = cuda.local.array((3, 3), dtype=float64)
+        XB = cuda.local.array((4, 3), dtype=float64)
+        X0B = cuda.local.array((4, 3), dtype=float64)
+
+        surface_indices = A_surface[idx_triA] 
+        for j in range(3):
+            for k in range(3): 
+                P[j, k] = A_x[surface_indices[j], k]
+        
+        tet_indices = B_T[idx_tetB] 
+        for j in range(4):
+            for k in range(3): 
+                XB[j, k] = B_x[tet_indices[j], k]
+                X0B[j, k] = B_x0[tet_indices[j], k]
+
+        P0 = cuda.local.array((3, 3), dtype=float64)
+        xform_triangle_to_model_space_device(P, XB, X0B, P0) 
+        
+        gradient_norms = cuda.local.array(3, dtype=float64)
+        gradient0 = cuda.local.array(3, float64)
+        gradient1 = cuda.local.array(3, float64)
+        gradient2 = cuda.local.array(3, float64)
+
+        Grid3.get_gradient_device(P0[0], B_grid_min_coord, B_grid_spacing, B_grid_I, B_grid_J, B_grid_K, B_grid_values, gradient0)
+        Grid3.get_gradient_device(P0[1], B_grid_min_coord, B_grid_spacing, B_grid_I, B_grid_J, B_grid_K, B_grid_values, gradient1)
+        Grid3.get_gradient_device(P0[2], B_grid_min_coord, B_grid_spacing, B_grid_I, B_grid_J, B_grid_K, B_grid_values, gradient2)
+
+        gradient_norms[0] = Vector.vec3_norm(gradient0)
+        gradient_norms[1] = Vector.vec3_norm(gradient1)
+        gradient_norms[2] = Vector.vec3_norm(gradient2)
+
+        x_i = cuda.local.array(3, dtype=float64)
+        for i in range(3):
+            x_i[i] = P0[Vector.argmin(gradient_norms, 3)][i]
+
+        for i in range(max_iteration):
+            t = cuda.local.array(3, dtype=float64)
+            Grid3.get_gradient_device(x_i, B_grid_min_coord, B_grid_spacing, B_grid_I, B_grid_J, B_grid_K, B_grid_values, t)
+
+            objectives = cuda.local.array(3, dtype=float64)
+            for j in range(3):
+                objectives[j] = Vector.vec3_dot(P0[j], t)
+            
+            vertex = Vector.argmin(objectives, 3)
+            s_i = P0[vertex]
+            alpha = 2 / (i + 2)
+
+            sx_sub = cuda.local.array(3, dtype=float64)
+            Vector.vec3_sub(s_i, x_i, sx_sub)
+
+            sx_sub_alpha = cuda.local.array(3, dtype=float64)
+            Vector.vec3_mut_scalar(sx_sub, alpha, sx_sub_alpha)
+
+            x_i_new = cuda.local.array(3, dtype=float64)
+            Vector.vec3_add(x_i, sx_sub_alpha, x_i_new)
+
+            for j in range(3):
+                x_i[j] = x_i_new[j]
+
+            if objectives[vertex] > optimization_tolerance:
+                break
+        
+        # contact point generation
+        if Grid3.is_inside_device(x_i, B_grid_min_coord, B_grid_max_coord, 0.5):
+            phi = Grid3.get_value_device(x_i, B_grid_min_coord, B_grid_spacing, B_grid_I, B_grid_J, B_grid_K, B_grid_values)
+            if phi < envelope:
+                gap = phi
+                n_res = cuda.local.array(3, dtype=float64)
+                Grid3.get_gradient_device(x_i, B_grid_min_coord, B_grid_spacing, B_grid_I, B_grid_J, B_grid_K, B_grid_values, n_res)
+                if Vector.vec3_norm(n_res) > 0:
+                    XA = cuda.local.array((4, 3), dtype=float64)
+                    indices = A_T[idx_tetA]
+                    for i in range(4):
+                        for j in range(3):
+                            XA[i][j] = A_x[indices[i], j]
+                    
+                    omegaB = cuda.local.array(4, dtype=float64)
+                    compute_omegaB_device(x_i, X0B, omegaB)
+                    p = cuda.local.array(3, dtype=float64)
+                    compute_p_device(x_i, XB, omegaB, p)
+                    omegaA = cuda.local.array(4, dtype=float64)
+                    compute_omegaA_device(p, XA, omegaA)
+                    n_res_new = cuda.local.array(3, dtype=float64)
+                    compute_n_device(n_res, XB, X0B, n_res_new)
+                    unit_n = cuda.local.array(3, dtype=float64)
+                    Vector.vec3_unit(n_res_new, unit_n)
+
+                    result['idx_tetB'] = idx_tetB
+                    result['idx_tetA'] = idx_tetA
+                    result['omegaB'] = omegaB
+                    result['omegaA'] = omegaA
+                    result['p'] = p
+                    result['unit_n'] = unit_n
+                    result['gap'] = gap
+
+                else:
+                    result['idx_tetB'] = -3
+                    result['idx_tetA'] = -3
+            else:
+                result['idx_tetB'] = -2
+                result['idx_tetA'] = -2
+        else:
+            result['idx_tetB'] = -1
+            result['idx_tetA'] = -1
+
+
+@cuda.jit(lineinfo=True)
+def contact_points_computing_kernel( d_bodyA_idxs, d_bodyB_idxs, d_overlaps, 
+                                    d_B_values, d_A_owners, d_B_owners, d_A_xs, 
+                                    d_B_xs, d_B_x0s, d_A_surfaces, d_A_Ts, d_B_Ts,
+                                    d_B_grid_min_coords, d_B_grid_max_coords, d_B_grid_spacings,
+                                    d_B_grid_Is, d_B_grid_Js, d_B_grid_Ks,
+                                    max_iterations, tolerance, envelope, boundary, result_gpu):
+    gid = cuda.grid(1)
+
+    if gid < d_overlaps.shape[0]:
+        bodyA_idx = d_bodyA_idxs[gid]
+        bodyB_idx = d_bodyB_idxs[gid]
+        idx_triA, idx_triB = d_overlaps[gid]
+        B_grid_values = d_B_values[gid]
+        A_owners = d_A_owners[gid]
+        B_owners = d_B_owners[gid]
+        A_x = d_A_xs[gid]
+        B_x = d_B_xs[gid]
+        B_x0 = d_B_x0s[gid]
+        A_surface = d_A_surfaces[gid]
+        A_T = d_A_Ts[gid]
+        B_T = d_B_Ts[gid]
+        B_grid_min_coord = d_B_grid_min_coords[gid]
+        B_grid_max_coord = d_B_grid_max_coords[gid]
+        B_grid_spacing = d_B_grid_spacings[gid]
+        B_grid_I = d_B_grid_Is[gid]
+        B_grid_J = d_B_grid_Js[gid]
+        B_grid_K = d_B_grid_Ks[gid]
+        
+
+        ## Those data maybe need to tansform to Shared Memory, but I just test two small bodies in scene, those data size total is over 30KB except the 'grid_values', and the 'grid_values' is over 4MB. Those data size is too large to put in Shared Memory. Maybe we need to consider other ways to optimize this.
+        
+
+        compute_contacts_device(idx_triA, idx_triB, A_owners, B_owners, A_x, B_x, B_x0, A_surface, A_T, B_T,  B_grid_min_coord, B_grid_max_coord, B_grid_spacing, B_grid_I, B_grid_J, B_grid_K, B_grid_values, max_iterations, tolerance, envelope, boundary, result_gpu[gid])
+

--- a/python/rainbow/cuda/collision_detection/compute_contacts.py
+++ b/python/rainbow/cuda/collision_detection/compute_contacts.py
@@ -10,6 +10,14 @@ import rainbow.cuda.geometry.grid3 as Grid3
 
 @cuda.jit(device=True)
 def xform_triangle_to_model_space_device(P, X, X0, P0):
+    """ Converts a world space triangle into the material space of a tetrahedron.
+
+    Args:
+        P (float64[:]): The input triangle points in world space
+        X (float64[:, :]): The input tetrahedron corners in world space.
+        X0 (float64[:, :]): The input tetrahedron corners in material space.
+        P0 (float64[:]): The values are the triangle corner points in tetrahedron B's material coordinate space.
+    """
     Matrix.mat33_zero(P0)
 
     w0 = cuda.local.array(4, dtype=float64)
@@ -29,144 +37,202 @@ def xform_triangle_to_model_space_device(P, X, X0, P0):
 
 
 @cuda.jit(device=True)
-def compute_omegaB_device(p, X0B, omegaB):
-    BC.compute_barycentric_tetrahedron_device(X0B[0], X0B[1], X0B[2], X0B[3], p, omegaB)
+def compute_omega_device(p, X, omega):
+    """ Compute the barycentric coordinates for a point p of a tetrahedron
+
+    Args:
+        p (float64[:]): The contact point in the model space of a body 
+        X (float64[:, :]): The corner points of a tetrahedron in world coordinates.
+        omega (float64[:]): the barycentric coordinates  w1, w2, w3 and w4.
+    """
+    BC.compute_barycentric_tetrahedron_device(X[0], X[1], X[2], X[3], p, omega)
+
+
+# @cuda.jit(device=True)
+# def compute_omegaB_device(p, X0B, omegaB):
+#     BC.compute_barycentric_tetrahedron_device(X0B[0], X0B[1], X0B[2], X0B[3], p, omegaB)
+
+
+# @cuda.jit(device=True)
+# def compute_omegaA_device(p, XA, omegaA):
+#     BC.compute_barycentric_tetrahedron_device(XA[0], XA[1], XA[2], XA[3], p, omegaA)
 
 
 @cuda.jit(device=True)
-def compute_omegaA_device(p, XA, omegaA):
-    BC.compute_barycentric_tetrahedron_device(XA[0], XA[1], XA[2], XA[3], p, omegaA)
+def compute_p_device(p, X, omega, result):
+    """ Compute the contact point in the world space of a body
 
-
-@cuda.jit(device=True)
-def compute_p_device(p, XB, omegaB, result):
+    Args:
+        p (float64[:]): The contact point in the model space of a body 
+        X (float64[:, :]): The corner points of a tetrahedron in world coordinates.
+        omega (float64[:]): the barycentric coordinates  w1, w2, w3 and w4.
+        result (float64[:]): The contact point in the world space of a body
+    """
     t = cuda.local.array((3, 4), dtype=float64)
-    Matrix.mat43_T(XB, t)
-    Matrix.mat34_dot_vec4(t, omegaB, result)
+    Matrix.mat43_T(X, t)
+    Matrix.mat34_dot_vec4(t, omega, result)
 
 
 @cuda.jit(device=True)
-def compute_n_device(n, XB, X0B, result):
+def compute_n_device(n, X, X0, result):
+    """ Compute the contact normal in the world space of a body
+
+    Args:
+        n (float64[:]): The contact normal in the model space of a body
+        X (flaot64[:, :]): The corner points of a tetrahedron in world coordinates.
+        X0 (flaot64[:, :]): The corner points of a tetrahedron in material coordinates.
+        result (float64[:]): The contact normal in the world space of a body
+    """
     D = cuda.local.array((3,3), dtype=float64)
     D0 = cuda.local.array((3, 3), dtype=float64)
     for i in range(3):
         for j in range(3):
-            D[i, j] = XB[i, j] - XB[3, j]
-            D0[i, j] = X0B[i, j] - X0B[3, j]
+            D[i, j] = X[i, j] - X[3, j]
+            D0[i, j] = X0[i, j] - X0[3, j]
     solve_res = cuda.local.array(3, dtype=float64)
     LinAlg.cramer_solver(D0, n, solve_res)
     Matrix.mat33_dot_vec3(D, solve_res, result)
 
 
 @cuda.jit(device=True)
-def compute_contacts_device(idx_triA, idx_triB, A_owners, B_owners, A_x, B_x, B_x0, A_surface, A_T, B_T,  B_grid_min_coord, B_grid_max_coord, B_grid_spacing, B_grid_I, B_grid_J, B_grid_K, B_grid_values, max_iteration, optimization_tolerance, envelope, boundary, result):
-        idx_tetA = A_owners[idx_triA][0]
-        idx_tetB = B_owners[idx_triB][0]
+def compute_contacts_device( idx_triA, idx_triB, A_owners, B_owners,
+                             A_x, B_x, B_x0, A_surface, A_T, B_T,  
+                             B_grid_min_coord, B_grid_max_coord, B_grid_spacing, 
+                             B_grid_I, B_grid_J, B_grid_K, B_grid_values, 
+                             max_iteration, optimization_tolerance, envelope, boundary, result):
+    """ Compute the contact points between a triangle and a tetrahedron.
 
-        P = cuda.local.array((3, 3), dtype=float64)
-        XB = cuda.local.array((4, 3), dtype=float64)
-        X0B = cuda.local.array((4, 3), dtype=float64)
+    Args:
+        idx_triA (int32): The index of the triangle in the triangle array of body A.
+        idx_triB (int32): The index of the triangle in the triangle array of body B.
+        A_owners (dict): The dict of the tetrahedra of body A that own the triangle.
+        B_owners (dict): The dict of the tetrahedra of body B that own the triangle.
+        A_x (float64[:, :]): The vertices in deformed coordinates of body A.
+        B_x (float64[:, :]): The vertices in deformed coordinates of body B.
+        B_x0 (float64[:, :]): The vertices in material coordinates of body B.
+        A_surface (int32[:, :]): The indices of the vertices of the triangle of body A.
+        A_T (int32[:, :]): The indices of the vertices of the tetrahedra of body A.
+        B_T (int32[:, :]): The indices of the vertices of the tetrahedra of body B.
+        B_grid_min_coord (float64): The minimum coordinate of the grid of body B.
+        B_grid_max_coord (float64): The maximum coordinate of the grid of body B.
+        B_grid_spacing (float64[:]): The spacing of the grid of body B.
+        B_grid_I (int32): The number of cells in the x-direction of the grid.
+        B_grid_J (int32): The number of cells in the y-direction of the grid.
+        B_grid_K (int32): The number of cells in the z-direction of the grid.
+        B_grid_values (float64[:]): It is an array storing signed distances of grid points to a given mesh.
+        max_iteration (int32): Maximum number of Gauss-Seidel iterations.
+        optimization_tolerance (float64): The tolerance for the frank wolfe collision detection algorithm.
+        envelope (float64): Any geometry within this distance generates a contact point.
+        boundary (float64):  The boundary width. This specifies how far inside the grid bounding box the     point has to be to be considered inside.
+        result (dcit): The data of the contact point computation for creating a ContactPoint instance on CPU.
+    """
+    idx_tetA = A_owners[idx_triA][0]
+    idx_tetB = B_owners[idx_triB][0]
 
-        surface_indices = A_surface[idx_triA] 
+    P = cuda.local.array((3, 3), dtype=float64)
+    XB = cuda.local.array((4, 3), dtype=float64)
+    X0B = cuda.local.array((4, 3), dtype=float64)
+
+    surface_indices = A_surface[idx_triA] 
+    for j in range(3):
+        for k in range(3): 
+            P[j, k] = A_x[surface_indices[j], k]
+        
+    tet_indices = B_T[idx_tetB] 
+    for j in range(4):
+        for k in range(3): 
+            XB[j, k] = B_x[tet_indices[j], k]
+            X0B[j, k] = B_x0[tet_indices[j], k]
+
+    P0 = cuda.local.array((3, 3), dtype=float64)
+    xform_triangle_to_model_space_device(P, XB, X0B, P0) 
+        
+    gradient_norms = cuda.local.array(3, dtype=float64)
+    gradient0 = cuda.local.array(3, float64)
+    gradient1 = cuda.local.array(3, float64)
+    gradient2 = cuda.local.array(3, float64)
+
+    Grid3.get_gradient_device(P0[0], B_grid_min_coord, B_grid_spacing, B_grid_I, B_grid_J, B_grid_K, B_grid_values, gradient0)
+    Grid3.get_gradient_device(P0[1], B_grid_min_coord, B_grid_spacing, B_grid_I, B_grid_J, B_grid_K, B_grid_values, gradient1)
+    Grid3.get_gradient_device(P0[2], B_grid_min_coord, B_grid_spacing, B_grid_I, B_grid_J, B_grid_K, B_grid_values, gradient2)
+
+    gradient_norms[0] = Vector.vec3_norm(gradient0)
+    gradient_norms[1] = Vector.vec3_norm(gradient1)
+    gradient_norms[2] = Vector.vec3_norm(gradient2)
+
+    x_i = cuda.local.array(3, dtype=float64)
+    for i in range(3):
+        x_i[i] = P0[Vector.argmin(gradient_norms, 3)][i]
+
+    for i in range(max_iteration):
+        t = cuda.local.array(3, dtype=float64)
+        Grid3.get_gradient_device(x_i, B_grid_min_coord, B_grid_spacing, B_grid_I, B_grid_J, B_grid_K, B_grid_values, t)
+
+        objectives = cuda.local.array(3, dtype=float64)
         for j in range(3):
-            for k in range(3): 
-                P[j, k] = A_x[surface_indices[j], k]
-        
-        tet_indices = B_T[idx_tetB] 
-        for j in range(4):
-            for k in range(3): 
-                XB[j, k] = B_x[tet_indices[j], k]
-                X0B[j, k] = B_x0[tet_indices[j], k]
-
-        P0 = cuda.local.array((3, 3), dtype=float64)
-        xform_triangle_to_model_space_device(P, XB, X0B, P0) 
-        
-        gradient_norms = cuda.local.array(3, dtype=float64)
-        gradient0 = cuda.local.array(3, float64)
-        gradient1 = cuda.local.array(3, float64)
-        gradient2 = cuda.local.array(3, float64)
-
-        Grid3.get_gradient_device(P0[0], B_grid_min_coord, B_grid_spacing, B_grid_I, B_grid_J, B_grid_K, B_grid_values, gradient0)
-        Grid3.get_gradient_device(P0[1], B_grid_min_coord, B_grid_spacing, B_grid_I, B_grid_J, B_grid_K, B_grid_values, gradient1)
-        Grid3.get_gradient_device(P0[2], B_grid_min_coord, B_grid_spacing, B_grid_I, B_grid_J, B_grid_K, B_grid_values, gradient2)
-
-        gradient_norms[0] = Vector.vec3_norm(gradient0)
-        gradient_norms[1] = Vector.vec3_norm(gradient1)
-        gradient_norms[2] = Vector.vec3_norm(gradient2)
-
-        x_i = cuda.local.array(3, dtype=float64)
-        for i in range(3):
-            x_i[i] = P0[Vector.argmin(gradient_norms, 3)][i]
-
-        for i in range(max_iteration):
-            t = cuda.local.array(3, dtype=float64)
-            Grid3.get_gradient_device(x_i, B_grid_min_coord, B_grid_spacing, B_grid_I, B_grid_J, B_grid_K, B_grid_values, t)
-
-            objectives = cuda.local.array(3, dtype=float64)
-            for j in range(3):
-                objectives[j] = Vector.vec3_dot(P0[j], t)
+            objectives[j] = Vector.vec3_dot(P0[j], t)
             
-            vertex = Vector.argmin(objectives, 3)
-            s_i = P0[vertex]
-            alpha = 2 / (i + 2)
+        vertex = Vector.argmin(objectives, 3)
+        s_i = P0[vertex]
+        alpha = 2 / (i + 2)
 
-            sx_sub = cuda.local.array(3, dtype=float64)
-            Vector.vec3_sub(s_i, x_i, sx_sub)
+        sx_sub = cuda.local.array(3, dtype=float64)
+        Vector.vec3_sub(s_i, x_i, sx_sub)
 
-            sx_sub_alpha = cuda.local.array(3, dtype=float64)
-            Vector.vec3_mut_scalar(sx_sub, alpha, sx_sub_alpha)
+        sx_sub_alpha = cuda.local.array(3, dtype=float64)
+        Vector.vec3_mut_scalar(sx_sub, alpha, sx_sub_alpha)
 
-            x_i_new = cuda.local.array(3, dtype=float64)
-            Vector.vec3_add(x_i, sx_sub_alpha, x_i_new)
+        x_i_new = cuda.local.array(3, dtype=float64)
+        Vector.vec3_add(x_i, sx_sub_alpha, x_i_new)
 
-            for j in range(3):
-                x_i[j] = x_i_new[j]
+        for j in range(3):
+            x_i[j] = x_i_new[j]
 
-            if objectives[vertex] > optimization_tolerance:
-                break
+        if objectives[vertex] > optimization_tolerance:
+            break
         
         # contact point generation
-        if Grid3.is_inside_device(x_i, B_grid_min_coord, B_grid_max_coord, 0.5):
-            phi = Grid3.get_value_device(x_i, B_grid_min_coord, B_grid_spacing, B_grid_I, B_grid_J, B_grid_K, B_grid_values)
-            if phi < envelope:
-                gap = phi
-                n_res = cuda.local.array(3, dtype=float64)
-                Grid3.get_gradient_device(x_i, B_grid_min_coord, B_grid_spacing, B_grid_I, B_grid_J, B_grid_K, B_grid_values, n_res)
-                if Vector.vec3_norm(n_res) > 0:
-                    XA = cuda.local.array((4, 3), dtype=float64)
-                    indices = A_T[idx_tetA]
-                    for i in range(4):
-                        for j in range(3):
-                            XA[i][j] = A_x[indices[i], j]
+    if Grid3.is_inside_device(x_i, B_grid_min_coord, B_grid_max_coord, 0.5):
+        phi = Grid3.get_value_device(x_i, B_grid_min_coord, B_grid_spacing, B_grid_I, B_grid_J, B_grid_K, B_grid_values)
+        if phi < envelope:
+            gap = phi
+            n_res = cuda.local.array(3, dtype=float64)
+            Grid3.get_gradient_device(x_i, B_grid_min_coord, B_grid_spacing, B_grid_I, B_grid_J, B_grid_K, B_grid_values, n_res)
+            if Vector.vec3_norm(n_res) > 0:
+                XA = cuda.local.array((4, 3), dtype=float64)
+                indices = A_T[idx_tetA]
+                for i in range(4):
+                    for j in range(3):
+                        XA[i][j] = A_x[indices[i], j]
                     
-                    omegaB = cuda.local.array(4, dtype=float64)
-                    compute_omegaB_device(x_i, X0B, omegaB)
-                    p = cuda.local.array(3, dtype=float64)
-                    compute_p_device(x_i, XB, omegaB, p)
-                    omegaA = cuda.local.array(4, dtype=float64)
-                    compute_omegaA_device(p, XA, omegaA)
-                    n_res_new = cuda.local.array(3, dtype=float64)
-                    compute_n_device(n_res, XB, X0B, n_res_new)
-                    unit_n = cuda.local.array(3, dtype=float64)
-                    Vector.vec3_unit(n_res_new, unit_n)
+                omegaB = cuda.local.array(4, dtype=float64)
+                compute_omega_device(x_i, X0B, omegaB)
+                p = cuda.local.array(3, dtype=float64)
+                compute_p_device(x_i, XB, omegaB, p)
+                omegaA = cuda.local.array(4, dtype=float64)
+                compute_omega_device(p, XA, omegaA)
+                n_res_new = cuda.local.array(3, dtype=float64)
+                compute_n_device(n_res, XB, X0B, n_res_new)
+                unit_n = cuda.local.array(3, dtype=float64)
+                Vector.vec3_unit(n_res_new, unit_n)
 
-                    result['idx_tetB'] = idx_tetB
-                    result['idx_tetA'] = idx_tetA
-                    result['omegaB'] = omegaB
-                    result['omegaA'] = omegaA
-                    result['p'] = p
-                    result['unit_n'] = unit_n
-                    result['gap'] = gap
+                result['idx_tetB'] = idx_tetB
+                result['idx_tetA'] = idx_tetA
+                result['omegaB'] = omegaB
+                result['omegaA'] = omegaA
+                result['p'] = p
+                result['unit_n'] = unit_n
+                result['gap'] = gap
 
-                else:
-                    result['idx_tetB'] = -3
-                    result['idx_tetA'] = -3
             else:
-                result['idx_tetB'] = -2
-                result['idx_tetA'] = -2
+                result['idx_tetB'] = -1
+                result['idx_tetA'] = -1
         else:
             result['idx_tetB'] = -1
             result['idx_tetA'] = -1
+    else:
+        result['idx_tetB'] = -1
+        result['idx_tetA'] = -1
 
 
 @cuda.jit(lineinfo=True)
@@ -176,6 +242,30 @@ def contact_points_computing_kernel( d_bodyA_idxs, d_bodyB_idxs, d_overlaps,
                                     d_B_grid_min_coords, d_B_grid_max_coords, d_B_grid_spacings,
                                     d_B_grid_Is, d_B_grid_Js, d_B_grid_Ks,
                                     max_iterations, tolerance, envelope, boundary, result_gpu):
+    """ This a kernel function for computing contact points between a triangle and a tetrahedron.
+
+    Args:
+        d_B_values (float64[:, :]): It is an array storing signed distances of grid points to a given mesh.
+        d_A_owners (list(dict)): The dict of the tetrahedra of body A that own the triangle.
+        d_B_owners (list(dict)): The dict of the tetrahedra of body B that own the triangle.
+        d_A_xs (float64[:, :, :]): The vertices in deformed coordinates of body A.
+        d_B_xs (float64[:, :, :]): The vertices in deformed coordinates of body B.
+        d_B_x0s (float64[:, :, :]): The vertices in material coordinates of body B.
+        d_A_surfaces (float64[:]): The indices of the vertices of the triangle of body A.
+        d_A_Ts (int32[:, :]): The indices of the vertices of the tetrahedra of body A.
+        d_B_Ts (int32[:, :]): The indices of the vertices of the tetrahedra of body B.
+        d_B_grid_min_coords (_type_): The minimum coordinate of the grid of body B.
+        d_B_grid_max_coords (float64[:]): The maximum coordinate of the grid of body B.
+        d_B_grid_spacings (float64[:]):  The spacing of the grid of body B.
+        d_B_grid_Is (int32[:]): The number of cells in the x-direction of the grid.
+        d_B_grid_Js (int32[:]): The number of cells in the y-direction of the grid.
+        d_B_grid_Ks (int32[:]): The number of cells in the z-direction of the grid.
+        max_iterations (int32): Maximum number of Gauss-Seidel iterations.
+        tolerance (float64): Maximum number of Gauss-Seidel iterations.
+        envelope (float64): Any geometry within this distance generates a contact point.
+        boundary (float64): The boundary width. This specifies how far inside the grid bounding box the     point has to be to be considered inside.
+        result_gpu (list(dict)): The data of the contact point computation for creating a ContactPoint instance on CPU.
+    """
     gid = cuda.grid(1)
 
     if gid < d_overlaps.shape[0]:
@@ -197,10 +287,5 @@ def contact_points_computing_kernel( d_bodyA_idxs, d_bodyB_idxs, d_overlaps,
         B_grid_I = d_B_grid_Is[gid]
         B_grid_J = d_B_grid_Js[gid]
         B_grid_K = d_B_grid_Ks[gid]
-        
-
-        ## Those data maybe need to tansform to Shared Memory, but I just test two small bodies in scene, those data size total is over 30KB except the 'grid_values', and the 'grid_values' is over 4MB. Those data size is too large to put in Shared Memory. Maybe we need to consider other ways to optimize this.
-        
 
         compute_contacts_device(idx_triA, idx_triB, A_owners, B_owners, A_x, B_x, B_x0, A_surface, A_T, B_T,  B_grid_min_coord, B_grid_max_coord, B_grid_spacing, B_grid_I, B_grid_J, B_grid_K, B_grid_values, max_iterations, tolerance, envelope, boundary, result_gpu[gid])
-

--- a/python/rainbow/cuda/collision_detection/compute_contacts.py
+++ b/python/rainbow/cuda/collision_detection/compute_contacts.py
@@ -48,16 +48,6 @@ def compute_omega_device(p, X, omega):
     BC.compute_barycentric_tetrahedron_device(X[0], X[1], X[2], X[3], p, omega)
 
 
-# @cuda.jit(device=True)
-# def compute_omegaB_device(p, X0B, omegaB):
-#     BC.compute_barycentric_tetrahedron_device(X0B[0], X0B[1], X0B[2], X0B[3], p, omegaB)
-
-
-# @cuda.jit(device=True)
-# def compute_omegaA_device(p, XA, omegaA):
-#     BC.compute_barycentric_tetrahedron_device(XA[0], XA[1], XA[2], XA[3], p, omegaA)
-
-
 @cuda.jit(device=True)
 def compute_p_device(p, X, omega, result):
     """ Compute the contact point in the world space of a body

--- a/python/rainbow/cuda/geometry/barycentric.py
+++ b/python/rainbow/cuda/geometry/barycentric.py
@@ -1,0 +1,60 @@
+from numba import cuda, float64
+import rainbow.cuda.math.vec as Vector
+import rainbow.cuda.math.linalg as LinAlg
+import rainbow.cuda.math.matrix as Matrix
+
+
+@cuda.jit(device=True)
+def compute_barycentric_tetrahedron_device(x1: float64[:], x2: float64[:], x3: float64[:], x4: float64[:], p: float64[:], result: float64[:]):
+    """ This method computes the barycentric coordinates for a point p of a tetrahedron
+        given by the points x1,x2,x3, x4 (in right-hand order).
+
+    Args:
+        x1 (float64[:]): The first point of the tetrahedron.
+        x2 (float64[:]): The second point of the tetrahedron.
+        x3 (float64[:]): The third point of the tetrahedron.
+        x4 (float64[:]): The fourth point of the tetrahedron.
+        p (float64[:]): The point for which the barycentric coordinates should be computed.
+        result (float64[:]): A quadruplet containing the first, second, third  abd fourth 
+                        barycentric coordinates  w1, w2, w3 and w4.
+    """
+    b1 = cuda.local.array(3, dtype=float64)
+    b2 = cuda.local.array(3, dtype=float64)
+    b3 = cuda.local.array(3, dtype=float64)
+
+    Vector.vec3_sub(x2, x1, b1)
+    Vector.vec3_sub(x3, x1, b2)
+    Vector.vec3_sub(x4, x1, b3)
+
+    cross_result = cuda.local.array(3, dtype=float64)
+    Vector.vec3_cross(b2, b3, cross_result)
+
+    if Vector.vec3_dot(b1, cross_result) > 0:
+        basic = cuda.local.array((3, 3), dtype=float64)
+        Matrix.mat33_make_from_cols(b1, b2, b3, basic)
+        p_sub_x1 = cuda.local.array(3, dtype=float64)
+        Vector.vec3_sub(p, x1, p_sub_x1)
+        q = cuda.local.array(3, dtype=float64)
+        LinAlg.cramer_solver(basic, p_sub_x1, q)
+        w1 = 1.0 - q[0] - q[1] - q[2]
+        w2 = q[0]
+        w3 = q[1]
+        w4 = q[2]
+    else:
+        basic = cuda.local.array((3, 3), dtype=float64)
+        Matrix.mat33_make_from_cols(b1, b3, b2, basic)
+        p_sub_x1 = cuda.local.array(3, dtype=float64)
+        Vector.vec3_sub(p, x1, p_sub_x1)
+        q = cuda.local.array(3, dtype=float64)
+        LinAlg.cramer_solver(basic, p_sub_x1, q)
+        
+        w1 = 1.0 - q[0] - q[1] - q[2]
+        w2 = q[0]
+        w3 = q[2]
+        w4 = q[1]
+    
+    result[0] = w1
+    result[1] = w2
+    result[2] = w3
+    result[3] = w4
+        

--- a/python/rainbow/cuda/geometry/grid3.py
+++ b/python/rainbow/cuda/geometry/grid3.py
@@ -1,0 +1,230 @@
+import numpy as np
+from numba import cuda, float64, int32, boolean
+import math
+
+
+@cuda.jit(device=True)
+def get_enclosing_cell_idx_device(p: float64[:], min_coord: float64[:], spacing: float64[:], I: int32, J: int32, K: int32, result: int32[:]):
+    """ This method computes the 3D cell index (i,j,k) of the grid cell that contains
+        the point p. If the cell index is out-of-bounds that is if p is outside the
+        grid then we project the cell index onto the closest cell index that is valid. This
+        is done by a simple projection to valid range of cell indices.
+
+    Args:
+        p (float64[:]): The 3D spatial point.
+        min_coord (float64[:]): The minimum corner of the grid.
+        spacing (float64[:]): The grid spacing.
+        I (int32): The number of cells in the x-direction of the grid.
+        J (int32): The number of cells in the y-direction of the grid.
+        K (int32): The number of cells in the z-direction of the grid.
+        result (float64[:]): The 3-tuple (i,j,k) that identifies the enclosing cell of the point p. Or the closest cell if p is outside the grid.
+    """
+    idx_x = math.floor((p[0] - min_coord[0]) / spacing[0])
+    idx_y = math.floor((p[1] - min_coord[1]) / spacing[1])
+    idx_z = math.floor((p[2] - min_coord[2]) / spacing[2])
+
+    i = int32(min(max(idx_x, 0), I - 2))
+    j = int32(min(max(idx_y, 0), J - 2))
+    k = int32(min(max(idx_z, 0), K - 2))
+
+    result[0] = i
+    result[1] = j
+    result[2] = k
+
+
+@cuda.jit(device=True)
+def get_linear_index_device(i: int32, j: int32, k: int32, I: int32, J: int32) -> int32:
+    """ This method converts from a 3D node index space (i,j,k) to a linear node idx space.
+
+    Args:
+        i (int32): The node index along the x-axis.
+        j (int32): The node index along the y-axis.
+        k (int32): The node index along the z-axis.
+        I (int32): The number of cells in the x-direction of the grid.
+        J (int32): The number of cells in the y-direction of the grid.
+        :return:   
+    Returns:
+        int32: The corresponding linear index of the 3D node index (i,j,k)
+    """
+    return int32(i + I * (j + J * k))
+
+
+@cuda.jit(device=True)
+def get_node_value_device(i: int32, j: int32, k: int32, values: float64[:], I: int32, J: int32) -> float64:
+    """ This method retrieves the grid value stored at the node with indices (i,j,k). The method
+        does not check if (i,j,k) are valid values. Hence if values are given outside the grid node
+        range then one should expect and access exception. Similar not test is done for whether the
+        internal value array has been allocated and filled with meaningful values.
+
+    Args:
+        i (int32): The node index along the x-axis.
+        j (int32): The node index along the y-axis.
+        k (int32): The node index along the z-axis.
+        values (float64[:]): It is an array storing signed distances of grid points to a given mesh.
+        I (int32): The number of cells in the x-direction of the grid.
+        J (int32): The number of cells in the y-direction of the grid.
+        result (float64[:]): The value stored at grid node with index (i,j,k). If grid has not been created properly
+                            or (i,j,k) does not exist then the behavior is undefined.
+    """
+    idx = get_linear_index_device(i, j, k, I, J)
+    return values[idx]
+
+
+@cuda.jit(device=True)
+def get_gradient_device(p: float64[:], min_coord: float64[:], spacing: float64[:], I: int32, J: int32, K: int32, values: float64[:], result: float64[:]):
+    """ This function compute the gradient of the scalar field that is sampled on the
+        supplied regular 3D grid. It is assumed that linear shape (basis) functions are
+        used for reconstruction of the scalar field. That is linear interpolation is the
+        building block. The gradient is computed by taking the spatial derivative of
+        that interpolation equation. If the point p is outside the bounding box
+        then the closest grid cell is used to interpolate the value that should be used
+        at p. This is a kind of Neumann condition that assumes the scalar field has constant
+        slope outside the grid bounding box. If one wish to implement other boundary conditions
+        the one can do so by first testing if the specified point is outside the grid bounding
+        box and then apply the desired boundary condition. If the point p is inside then one can
+        simply use the interpolated value of this function.
+
+    Args:
+        p (float64[:]): The 3D spatial point.
+        min_coord (float64[:]): The minimum corner of the grid.
+        spacing (float64[:]): The grid spacing.
+        I (int32): The number of cells in the x-direction of the grid.
+        J (int32): The number of cells in the y-direction of the grid.
+        K (int32): The number of cells in the z-direction of the grid.
+        values (float64[:]): It is an array storing signed distances of grid points to a given mesh.
+        result (float64[:]): The gradient value of the scalar field at position p
+    """
+    arr = cuda.local.array(3, dtype=float64)
+    get_enclosing_cell_idx_device(p, min_coord, spacing, I, J, K, arr)
+    i = arr[0]
+    j = arr[1]
+    k = arr[2]
+
+    d000 = get_node_value_device(i, j, k, values, I, J)
+    d001 = get_node_value_device(i, j, k + 1, values, I, J)
+    d010 = get_node_value_device(i, j + 1, k, values, I, J)
+    d011 = get_node_value_device(i, j + 1, k + 1, values, I, J)
+    d100 = get_node_value_device(i + 1, j, k, values, I, J)
+    d101 = get_node_value_device(i + 1, j, k + 1, values, I, J)
+    d110 = get_node_value_device(i + 1, j + 1, k, values, I, J)
+    d111 = get_node_value_device(i + 1, j + 1, k + 1, values, I, J)
+
+    s = (p[0] - (i * spacing[0] + min_coord[0])) / min_coord[0]
+    t = (p[1] - (j * spacing[1] + min_coord[1])) / min_coord[1]
+    u = (p[2] - (k * spacing[2] + min_coord[2])) / min_coord[2]
+
+    x00 = (d100 - d000) * s + d000
+    x01 = (d101 - d001) * s + d001
+    x10 = (d110 - d010) * s + d010
+    x11 = (d111 - d011) * s + d011
+    y0 = (x10 - x00) * t + x00
+    y1 = (x11 - x01) * t + x01
+    dx00_ds = d100 - d000
+    dx01_ds = d101 - d001
+    dx10_ds = d110 - d010
+    dx11_ds = d111 - d011
+    dy0_ds = (dx10_ds - dx00_ds) * t + dx00_ds
+    dy1_ds = (dx11_ds - dx01_ds) * t + dx01_ds
+    dy0_dt = x10 - x00
+    dy1_dt = x11 - x01
+
+    dp_ds = (dy1_ds - dy0_ds) * u + dy0_ds
+    dp_dt = (dy1_dt - dy0_dt) * u + dy0_dt
+    dp_du = y1 - y0
+
+    ds_dx = 1.0 / spacing[0]
+    dt_dy = 1.0 / spacing[1]
+    du_dz = 1.0 / spacing[2]
+
+    dp_dx = dp_ds * ds_dx
+    dp_dy = dp_dt * dt_dy
+    dp_dz = dp_du * du_dz
+
+    result[0] = dp_dx
+    result[1] = dp_dy
+    result[2] = dp_dz
+
+
+@cuda.jit(device=True)
+def is_inside_device(p: float64[:], min_coord: float64[:], max_coord: float64[:], boundary: float64) -> boolean:
+    """ This function test if the given spatial 3D point is inside the given grid and the boundary value.
+
+
+    Args:
+        p (float64[:]): The 3D spatial point.
+        min_coord (float64[:]): The minimum corner of the grid.
+        max_coord (float64[:]): The maximum corner of the grid.
+        boundary (float, optional): The boundary width. This specifies how far inside the grid bounding box the     point has to be to be considered inside. Using a value of zero means one is testing on the bounding box itself.. Defaults to 0.5.
+
+    Returns:
+        bool: True if the given point is inside the given grid.
+    """
+    if p[0] > (max_coord[0] - boundary):
+        return False
+    if p[1] > (max_coord[1] - boundary):
+        return False
+    if p[2] > (max_coord[2] - boundary):
+        return False
+
+    if p[0] < (min_coord[0] + boundary):
+        return False
+    if p[1] < (min_coord[1] + boundary):
+        return False
+    if p[2] < (min_coord[2] + boundary):
+        return False
+    return True
+
+
+@cuda.jit(device=True)
+def get_value_device(p: float64[:], min_coord: float64[:], spacing: float64[:], I: int32, J: int32, K: int32, values: float64[:]) -> float64:
+    """ This function compute the value of the scalar field that is sampled on the
+        supplied regular 3D grid. It is assumed that linear shape (basis) functions are
+        used for reconstruction of the scalar field. That is linear interpolation is the
+        building block. If the point p is outside the grid bounding box
+        then the closest grid cell is used to interpolate the value that should be used
+        at p. This is a kind of Neumann condition that assumes the scalar field has constant
+        slope outside the grid bounding box. If one wish to implement other boundary conditions
+        the one can do so by first testing if the specified point is outside the grid bounding
+        box and then apply the desired boundary condition. If the point p is inside then one can
+        simply use the interpolated value of this function.
+
+    Args:
+        p (float64[:]): The 3D spatial point.
+        min_coord (float64[:]): The minimum corner of the grid.
+        spacing (float64[:]): The grid spacing.
+        I (int32): The number of cells in the x-direction of the grid.
+        J (int32): The number of cells in the y-direction of the grid.
+        K (int32): The number of cells in the z-direction of the grid.
+        values (float64[:]): It is an array storing signed distances of grid points to a given mesh.
+
+    Returns:
+        float64: The value of the scalar field at position p
+    """
+    temp_res = cuda.local.array(3, dtype=int32)
+    get_enclosing_cell_idx_device(p, min_coord, spacing, I, J, K, temp_res)
+    i = temp_res[0]
+    j = temp_res[1]
+    k = temp_res[2]
+    
+    d000 = get_node_value_device(i, j, k, values, I, J)
+    d001 = get_node_value_device(i, j, k + 1, values, I, J)
+    d010 = get_node_value_device(i, j + 1, k, values, I, J)
+    d011 = get_node_value_device(i, j + 1, k + 1, values, I, J)
+
+    d100 = get_node_value_device(i + 1, j, k, values, I, J)
+    d101 = get_node_value_device(i + 1, j, k + 1, values, I, J)
+    d110 = get_node_value_device(i + 1, j + 1, k, values, I, J)
+    d111 = get_node_value_device(i + 1, j + 1, k + 1, values, I, J)
+
+    s = (p[0] - ((i * spacing[0]) + min_coord[0])) / spacing[0]
+    t = (p[1] - ((j * spacing[1]) + min_coord[1])) / spacing[1]
+    u = (p[2] - ((k * spacing[2]) + min_coord[2])) / spacing[2]
+
+    x00 = (d100 - d000) * s + d000
+    x01 = (d101 - d001) * s + d001
+    x10 = (d110 - d010) * s + d010
+    x11 = (d111 - d011) * s + d011
+    y0 = (x10 - x00) * t + x00
+    y1 = (x11 - x01) * t + x01
+    z = (y1 - y0) * u + y0
+    return z

--- a/python/rainbow/cuda/geometry/grid3.py
+++ b/python/rainbow/cuda/geometry/grid3.py
@@ -149,7 +149,6 @@ def get_gradient_device(p: float64[:], min_coord: float64[:], spacing: float64[:
 def is_inside_device(p: float64[:], min_coord: float64[:], max_coord: float64[:], boundary: float64) -> boolean:
     """ This function test if the given spatial 3D point is inside the given grid and the boundary value.
 
-
     Args:
         p (float64[:]): The 3D spatial point.
         min_coord (float64[:]): The minimum corner of the grid.

--- a/python/rainbow/cuda/math/linalg.py
+++ b/python/rainbow/cuda/math/linalg.py
@@ -1,0 +1,44 @@
+import math
+from numba import cuda, types, float64, int32
+from rainbow.cuda.math.vec import vec3_zero
+from rainbow.cuda.math.matrix import  mat33_determinant
+
+
+@cuda.jit(device=True)
+def cramer_solver(A: float64[:, :], b: float64[:], result: float64[:]):
+    """ Solve a linear system Ax = b using Cramer's rule,
+        refer to https://en.wikipedia.org/wiki/Cramer%27s_rule,
+
+    Note: Currently, we use the Cramer's rule to solve the linear system, which is a fast method but not stable when det(A) = 0. With Numba cuda, we do not find a stable and fast library to solve the linear system.
+
+    Args:
+        A (float64[:, :]): a matrix 3*3
+        b (float64[:]): a vector
+        result (float64[:]): the result of the linear system
+    """
+    detA = mat33_determinant(A)
+    if detA == 0.0:
+        vec3_zero(result)
+    else:
+        Ax = cuda.local.array((3, 3), dtype=float64)
+        Ay = cuda.local.array((3, 3), dtype=float64)
+        Az = cuda.local.array((3, 3), dtype=float64)
+
+        for i in range(3):
+            for j in range(3):
+                Ax[i, j] = A[i, j]
+                Ay[i, j] = A[i, j]
+                Az[i, j] = A[i, j]
+
+        for i in range(3):
+            Ax[i, 0] = b[i]
+            Ay[i, 1] = b[i]
+            Az[i, 2] = b[i]
+
+        x = mat33_determinant(Ax) / detA
+        y = mat33_determinant(Ay) / detA
+        z = mat33_determinant(Az) / detA
+
+        result[0] = x
+        result[1] = y
+        result[2] = z

--- a/python/rainbow/cuda/math/matrix.py
+++ b/python/rainbow/cuda/math/matrix.py
@@ -1,0 +1,131 @@
+import math
+from numba import cuda, types, float64, int32
+
+
+@cuda.jit(device=True)
+def mat33_T(M: float64[:, :], result: float64[:, :]):
+    """ The transpose of a matrix
+
+    Args:
+        M (float64[:, :]): a matrix 3*3
+        result (float64[:, :]): the result of the transpose
+    """
+    for i in range(3):
+        for j in range(3):
+            result[i, j] = M[j, i]
+    return result
+
+
+@cuda.jit(device=True)
+def mat33_zero(result: float64[:, :]):
+    """ Return a zero matrix.
+
+    Args:
+        result (float64[:, :]): the matrix data
+    """
+    for i in range(3):
+        for j in range(3):
+            result[i, j] = 0.0
+
+
+@cuda.jit(device=True)
+def mat33_determinant(M: float64[:, :]) -> float64:
+    """ Return the determinant of a matrix
+
+    Args:
+        M (float64[:, :]): a matrix 3*3
+    """
+    return M[0, 0] * (M[1, 1] * M[2, 2] - M[1, 2] * M[2, 1]) - \
+              M[0, 1] * (M[1, 0] * M[2, 2] - M[1, 2] * M[2, 0]) + \
+                M[0, 2] * (M[1, 0] * M[2, 1] - M[1, 1] * M[2, 0])
+
+
+@cuda.jit(device=True)
+def mat33_make(M00: float64,
+               M01: float64,
+               M02: float64,
+               M10: float64,
+               M11: float64,
+               M12: float64,
+               M20: float64,
+               M21: float64,
+               M22: float64,
+               result: float64[:, :]):
+    """ Make a 3*3 matrix
+
+    Args:
+        Mij (float64): the element of the matrix (i and j are from 0 to 2)
+        result (float64[:, :]): the 3*3 matrix 
+    """
+    result[0, 0] = M00
+    result[0, 1] = M01
+    result[0, 2] = M02
+    result[1, 0] = M10
+    result[1, 1] = M11
+    result[1, 2] = M12
+    result[2, 0] = M20
+    result[2, 1] = M21
+    result[2, 2] = M22
+
+
+@cuda.jit(device=True)
+def mat33_make_from_cols(col0: float64[:], col1: float64[:], col2: float64[:], result: float64[:, :]):
+    """ Make a 3*3 matrix from three column vectors
+
+    Args:
+        col0 (float64[:]): the first column vector
+        col1 (float64[:]): the second column vector
+        col2 (float64[:]): the third column vector
+        result (float64[:, :]): the 3*3 matrix
+    """
+    mat33_make(
+        col0[0], col1[0], col2[0],
+        col0[1], col1[1], col2[1],
+        col0[2], col1[2], col2[2],
+        result
+    )
+
+
+@cuda.jit(device=True)
+def mat33_dot_vec3(M: float64[:, :], V3: float64[:], result: float64[:]):
+    """ Dot product of a matrix and a vector
+
+    Args:
+        M (float64[:, :]): a matrix 3*3
+        V3 (float64[:]): a vector 3
+        result (float64[:]): the result of the dot product
+    """
+    for i in range(3):
+        sum= 0.0
+        for j in range(3):
+            sum += M[i, j] * V3[j]
+        result[i] = sum
+
+
+@cuda.jit(device=True)
+def mat43_T(M: float64[:, :], result: float64[:, :]):
+    """ The transpose of a matrix
+
+    Args:
+        M (float64[:, :]): a matrix 4*3
+        result (float64[:, :]): the result of the transpose
+    """
+    for j in range(3):
+        for i in range(4):
+            result[j, i] = M[i, j]
+
+
+@cuda.jit(device=True)
+def mat34_dot_vec4(M: float64[:, :], vec4: float64[:], result: float64[:]):
+    """ Dot product of a matrix and a vector
+
+    Args:
+        M (float64[:, :]): a matrix 3*4
+        vec4 (float64[:]): a vector 4
+        result (float64[:]): the result of the dot product
+    """
+    for i in range(3):
+        sum= 0.0
+        for j in range(4):
+            sum += M[i, j] * vec4[j]
+        result[i] = sum

--- a/python/rainbow/cuda/math/vec.py
+++ b/python/rainbow/cuda/math/vec.py
@@ -1,0 +1,128 @@
+import math
+from numba import cuda, float64, int32
+
+
+@cuda.jit(device=True)
+def vec3_zero(result: float64[:]):
+    """ Return a zero vector.
+
+    Args:
+        result (float64[:]): the vector data
+    """
+    result[0] = 0.0
+    result[1] = 0.0
+    result[2] = 0.0
+
+
+@cuda.jit(device=True)
+def vec3_norm(v: float64[:]):
+    """ Return the norm of a vector.
+
+    Args:
+        v (float64[:]): a vector
+    """
+    return math.sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2])    
+
+
+@cuda.jit(device=True)
+def vec3_unit(v: float64[:], result: float64[:]):
+    """ Return the unit vector
+
+    Args:
+        v (float64[:]): a vector
+        result (float64[:]): the unit vector data
+    """
+    norm = vec3_norm(v)
+
+    result[0] = v[0] / norm
+    result[1] = v[1] / norm
+    result[2] = v[2] / norm
+
+
+@cuda.jit(device=True)
+def vec3_add(v1: float64[:], v2: float64[:], result: float64[:]):
+    """ The addition of two vectors
+
+    Args:
+        v1 (float64[:]): a vector
+        v2 (float64[:]): a vector
+        result (float64[:]): the result of the addition
+    """
+    result[0] = v1[0] + v2[0]
+    result[1] = v1[1] + v2[1]
+    result[2] = v1[2] + v2[2]
+
+
+@cuda.jit(device=True)
+def vec3_sub(v1: float64[:], v2: float64[:], result: float64[:]):
+    """ The subtraction of two vectors
+
+    Args:
+        v1 (float64[:]): a vector
+        v2 (float64[:]): a vector
+        result (float64[:]): the result of the subtraction
+    """
+    result[0] = v1[0] - v2[0]
+    result[1] = v1[1] - v2[1]
+    result[2] = v1[2] - v2[2]
+
+
+@cuda.jit(device=True)
+def vec3_dot(v1: float64[:], v2: float64[:]) -> float64:
+    """ The dot product of two vectors
+
+    Args:
+        v1 (float64[:]): a vector
+        v2 (float64[:]): a vector
+        result (float64[:]): the result of the dot product
+    """
+    return v1[0] * v2[0] + v1[1] * v2[1] + v1[2] * v2[2]
+
+
+@cuda.jit(device=True)
+def vec3_cross(v1: float64[:], v2: float64[:], result: float64[:]):
+    """ The cross product of two vectors
+
+    Args:
+        v1 (float64[:]): a vector
+        v2 (float64[:]): a vector
+        result (float64[:]): the result of the cross product
+    """
+    result[0] = v1[1] * v2[2] - v1[2] * v2[1]
+    result[1] = v1[2] * v2[0] - v1[0] * v2[2]
+    result[2] = v1[0] * v2[1] - v1[1] * v2[0]
+
+
+@cuda.jit(device=True)
+def vec3_mut_scalar(v1: float64[:], n: float64, result: float64[:]):
+    """ The multiplication of a vector by a scalar
+
+    Args:
+        v1 (float64[:]): a vector
+        v2 (float64[:]): a scalar
+        result (float64[:]): the result of the multiplication
+    """
+    result[0] = v1[0] * n
+    result[1] = v1[1] * n
+    result[2] = v1[2] * n
+
+
+@cuda.jit(device=True)
+def argmin(a: float64[:], size: int32) -> int32:
+    """ Return the index of the minimum value in a vector
+
+    Args:
+        a (float64[:]): a vector
+        size (int32): the size of the vector or the number of elements to consider
+    """
+    min_val = a[0]
+    min_idx = 0
+
+    size = min(size, a.shape[0])
+
+    for i in range(size):
+        if a[i] < min_val:
+            min_val = a[i]
+            min_idx = i
+
+    return min_idx

--- a/python/rainbow/cuda/unit_tests/test_geometry_barycentric_kernel.py
+++ b/python/rainbow/cuda/unit_tests/test_geometry_barycentric_kernel.py
@@ -1,0 +1,19 @@
+import numpy as np
+from numba import cuda, float64, int32, boolean
+import rainbow.cuda.geometry.barycentric as BC
+
+
+@cuda.jit
+def compute_barycentric_tetrahedron_kernel(x1s: float64[:, :], x2s: float64[:, :], x3s: float64[:, :], x4s: float64[:, :], ps: float64[:, :], result: float64[:, :]):
+    """ Unit test kernel function for compute_barycentric_tetrahedron_device
+    
+    Args:
+        x1s (float64[:, :]): The list of the first point of the tetrahedron.
+        x2s (float64[:, :]): The list of the second point of the tetrahedron.
+        x3s (float64[:, :]): The list of the third point of the tetrahedron.
+        x4s (float64[:, :]): The list of the fourth point of the tetrahedron.
+        ps (float64[:, :]): The list of the points.
+        result (float64[:, :]): this is the result array from host.
+    """
+    tid = cuda.threadIdx.x
+    BC.compute_barycentric_tetrahedron_device(x1s[tid, :], x2s[tid, :], x3s[tid, :], x4s[tid, :], ps[tid, :], result[tid, :])

--- a/python/rainbow/cuda/unit_tests/test_geometry_grid3_kernel.py
+++ b/python/rainbow/cuda/unit_tests/test_geometry_grid3_kernel.py
@@ -1,0 +1,88 @@
+import numpy as np
+from numba import cuda, float64, int32, boolean
+import rainbow.cuda.geometry.grid3 as GRID3
+
+
+@cuda.jit
+def get_enclosing_cell_idx_kernel(p: float64[:, :], min_coord: float64[:, :], spacing: float64[:, :], I: int32[:], J: int32[:], K: int32[:], result: int32[:, :]):
+    """ Unit test kernel function for get_enclosing_cell_idx_device
+
+    Args:
+        p (float64[:, :]): The 3D spatial point.
+        min_coord (float64[:, :]): The minimum corner of the grid.
+        spacing (float64[:, :]): The grid spacing.
+        I (int32[:]): The number of cells in the x-direction of the grid.
+        J (int32[:]): The number of cells in the y-direction of the grid.
+        K (int32[:]): The number of cells in the z-direction of the grid.
+        result (float64[:, :]): this is the result array from host.
+    """
+    tid = cuda.threadIdx.x
+    GRID3.get_enclosing_cell_idx_device(p[tid, :], min_coord[tid, :], spacing[tid, :], I[tid], J[tid], K[tid], result[tid, :])
+
+
+@cuda.jit
+def get_value_kernel(p: float64[:, :], min_coord: float64[:, :], spacing: float64[:, :], I: int32[:], J: int32[:], K: int32[:], values: float64[:, :], result: float64[:]):
+    """ Unit test kernel function for get_value_device
+
+    Args:
+        p (float64[:, :]): The 3D spatial point.
+        min_coord (float64[:, :]): The minimum corner of the grid.
+        spacing (float64[:, :]): The grid spacing.
+        I (int32[:]): The number of cells in the x-direction of the grid.
+        J (int32[:]): The number of cells in the y-direction of the grid.
+        K (int32[:]): The number of cells in the z-direction of the grid.
+        values (float64[:, :]): It is an array storing signed distances of grid points to a given mesh.
+        result (float64[:]): this is the result array from host.
+    """
+    tid = cuda.threadIdx.x
+    result[tid] = GRID3.get_value_device(p[tid, :], min_coord[tid, :], spacing[tid, :], I[tid], J[tid], K[tid], values[tid, :])
+
+
+@cuda.jit
+def get_node_value_kernel(i: int32[:], j: int32[:], k: int32[:], values: float64[:, :], I: int32[:], J: int32[:], result: float64[:]):
+    """ Unit test kernel function for get_node_value_device
+
+    Args:
+        i (int32[:]): The i-coordinate of the grid.
+        j (int32[:]): The j-coordinate of the grid.
+        k (int32[:]): The k-coordinate of the grid.
+        values (float64[:, :]): It is an array storing signed distances of grid points to a given mesh.
+        I (int32[:]): The number of cells in the x-direction of the grid.
+        J (int32[:]): The number of cells in the y-direction of the grid.
+        result (float64[:]): this is the result array from host.
+    """
+    tid = cuda.threadIdx.x
+    result[tid] = GRID3.get_node_value_device(i[tid], j[tid], k[tid], values[tid, :], I[tid], J[tid], )
+
+
+@cuda.jit
+def is_inside_kernel(p: float64[:, :], min_coord: float64[:, :], max_coord: float64[:, :], boundary: float64[:], result: boolean[:]):
+    """ Unit test kernel function for is_inside_device
+
+    Args:
+        p (float64[:, :]): The 3D spatial point.
+        min_coord (float64[:, :]): The minimum corner of the grid.
+        max_coord (float64[:, :]): The maximum corner of the grid.
+        boundary (float64[:]): The boundary of the grid.
+        result (boolean[:]): this is the result array from host.
+    """
+    tid = cuda.threadIdx.x
+    result[tid] = GRID3.is_inside_device(p[tid, :], min_coord[tid, :], max_coord[tid, :], boundary[tid])
+
+
+@cuda.jit
+def get_gradient_kernel(p: float64[:, :], min_coord: float64[:, :], spacing: float64[:, :], I: int32[:], J: int32[:], K: int32[:], values: float64[:, :], result: float64[:, :]):
+    """ Unit test kernel function for get_gradient_device
+
+    Args:
+        p (float64[:, :]): The 3D spatial point.
+        min_coord (float64[:, :]): The minimum corner of the grid.
+        spacing (float64[:, :]): The grid spacing.
+        I (int32[:]): The number of cells in the x-direction of the grid.
+        J (int32[:]): The number of cells in the y-direction of the grid.
+        K (int32[:]): The number of cells in the z-direction of the grid.
+        values (float64[:, :]): It is an array storing signed distances of grid points to a given mesh.
+        result (float64[:, :]): this is the result array from host.
+    """
+    tid = cuda.threadIdx.x
+    GRID3.get_gradient_device(p[tid, :], min_coord[tid, :], spacing[tid, :], I[tid], J[tid], K[tid], values[tid, :], result[tid, :])

--- a/python/rainbow/cuda/unit_tests/test_math_linalg_kernel.py
+++ b/python/rainbow/cuda/unit_tests/test_math_linalg_kernel.py
@@ -1,0 +1,17 @@
+import numpy as np
+from numba import cuda, float64, int32
+import rainbow.cuda.math.linalg as LinAlg
+
+
+@cuda.jit
+def cramer_solver_kernel(A: float64[:, :, :], b: float64[:, :], result: float64[:, :]):
+    """ Unit test kernel function for cramer_solver_device
+
+    Args:
+        A (float[:, :, :]): it is a list of matrix
+        b (float[:, ;]): It is a list of vector
+        result (float64[:, :]): this is the result array from host.
+    """
+    tid = cuda.threadIdx.x
+    LinAlg.cramer_solver(A[tid, :, :], b[tid, :], result[tid, :])
+

--- a/python/rainbow/cuda/unit_tests/test_math_matrix_kernel.py
+++ b/python/rainbow/cuda/unit_tests/test_math_matrix_kernel.py
@@ -87,6 +87,7 @@ def mat33_dot_vec3_kernel(M: float64[:, :, :], V3: float64[:, :], result: float6
     tid = cuda.threadIdx.x
     Matrix.mat33_dot_vec3(M[tid, :, :], V3[tid, :], result[tid, :])
 
+
 @cuda.jit
 def mat43_T_kernel(M: float64[:, :, :], result: float64[:, :, :]):
     """ Unit test kernel function for mat43_T_device

--- a/python/rainbow/cuda/unit_tests/test_math_matrix_kernel.py
+++ b/python/rainbow/cuda/unit_tests/test_math_matrix_kernel.py
@@ -1,0 +1,112 @@
+import numpy as np
+from numba import cuda, float64, int32
+import rainbow.cuda.math.matrix as Matrix
+
+
+@cuda.jit
+def mat33_T_kernel(M: float64[:, :, :], result: float64[:, :, :]):
+    """ Unit test kernel function for mat33_T_device
+
+    Args:
+        M (float64[:, :, :]): it is a list of matrix
+        result (float64[:, :, :]): this is the result array from host.
+    """
+    tid = cuda.threadIdx.x
+    Matrix.mat33_T(M[tid, :, :], result[tid, :, :])
+
+
+@cuda.jit
+def mat33_zero_kernel(result: float64[:, :, :]):
+    """ Unit test kernel function for mat33_zero_device
+
+    Args:
+        result (float64[:, :, :]): this is the result array from host.
+    """
+    tid = cuda.threadIdx.x
+    Matrix.mat33_zero(result[tid, :, :])
+
+
+@cuda.jit
+def mat33_determinant_kernel(M: float64[:, :, :], result: float64[:]):
+    """ Unit test kernel function for mat33_determinant_device
+
+    Args:
+        M (float64[:, :, :]): it is a list of matrix
+        result (float64[:]): this is the result array from host.
+    """
+    tid = cuda.threadIdx.x
+    result[tid] = Matrix.mat33_determinant(M[tid, :, :])
+
+
+@cuda.jit
+def mat33_make_kernel(M00: float64[:], M01: float64[:], M02: float64[:], M10: float64[:], M11: float64[:], M12: float64[:], M20: float64[:], M21: float64[:], M22: float64[:], result: float64[:, :, :]):
+    """ Unit test kernel function for mat33_make_device
+
+    Args:
+        M00 (float64[:]): The 00 element of the matrix.
+        M01 (float64[:]): The 01 element of the matrix.
+        M02 (float64[:]): The 02 element of the matrix.
+        M10 (float64[:]): The 10 element of the matrix.
+        M11 (float64[:]): The 11 element of the matrix.
+        M12 (float64[:]): The 12 element of the matrix.
+        M20 (float64[:]): The 20 element of the matrix.
+        M21 (float64[:]): The 21 element of the matrix.
+        M22 (float64[:]): The 22 element of the matrix.
+        result (float64[:, :, :]): this is the result array from host.
+    """
+    tid = cuda.threadIdx.x
+    Matrix.mat33_make(M00[tid], M01[tid], M02[tid], 
+                      M10[tid], M11[tid], M12[tid], 
+                      M20[tid], M21[tid], M22[tid], 
+                      result[tid, :, :])
+
+
+@cuda.jit
+def mat33_make_from_cols_kernel(col0: float64[:, :], col1: float64[:, :], col2: float64[:, :], result: float64[:, :, :]):
+    """ Unit test kernel function for mat33_make_from_cols_device
+
+    Args:
+        col0 (float64[:, :]): The 0-th column of the matrix.
+        col1 (float64[:, :]): The 1-th column of the matrix.
+        col2 (float64[:, :]): The 2-th column of the matrix.
+        result (float64[:, :, :]): this is the result array from host.
+    """
+    tid = cuda.threadIdx.x
+    Matrix.mat33_make_from_cols(col0[tid, :], col1[tid, :], col2[tid, :], result[tid, :, :])
+
+
+@cuda.jit
+def mat33_dot_vec3_kernel(M: float64[:, :, :], V3: float64[:, :], result: float64[:, :]):
+    """ Unit test kernel function for mat33_dot_vec3_device
+
+    Args:
+        M (float64[:, :, :]): it is a list of matrix
+        V3 (float64[:, :]): it is a list of vector
+        result (float64[:, :]): this is the result array from host.
+    """
+    tid = cuda.threadIdx.x
+    Matrix.mat33_dot_vec3(M[tid, :, :], V3[tid, :], result[tid, :])
+
+@cuda.jit
+def mat43_T_kernel(M: float64[:, :, :], result: float64[:, :, :]):
+    """ Unit test kernel function for mat43_T_device
+
+    Args:
+        M (float64[:, :, :]): it is a list of matrix
+        result (float64[:, :, :]): this is the result array from host.
+    """
+    tid = cuda.threadIdx.x
+    Matrix.mat43_T(M[tid, :, :], result[tid, :, :])
+
+
+@cuda.jit
+def mat34_dot_vec4_kernel(M: float64[:, :, :], vec4: float64[:, :], result: float64[:, :]):
+    """ Unit test kernel function for mat34_dot_vec4_device
+
+    Args:
+        M (float64[:, :, :]): it is a list of matrix
+        vec4 (float64[:, :]): it is a list of vector
+        result (float64[:, :]): this is the result array from host.
+    """
+    tid = cuda.threadIdx.x
+    Matrix.mat34_dot_vec4(M[tid, :, :], vec4[tid, :], result[tid, :])

--- a/python/rainbow/cuda/unit_tests/test_math_vec_kernel.py
+++ b/python/rainbow/cuda/unit_tests/test_math_vec_kernel.py
@@ -1,0 +1,116 @@
+import numpy as np
+from numba import cuda, float64, int32
+import rainbow.cuda.math.vec as Vec
+
+
+@cuda.jit
+def vec3_add_kernel(v1: float64[:, :], v2: float64[:, :], result: float64[:, :]):
+    """ Unit test kernel function for vec3_add_device
+
+    Args:
+        v1 (float64[:, :]): it is a list of vector
+        v2 (float64[:, :]): It is a list of vector
+        result (float64[:, :]): this is the result array from host.
+    """
+    tid = cuda.threadIdx.x
+    Vec.vec3_add(v1[tid, :], v2[tid, :], result[tid, :])
+
+
+@cuda.jit
+def vec3_sub_kernel(v1: float64[:, :], v2: float64[:, :], result: float64[:, :]):
+    """ Unit test kernel function for vec3_sub_device
+
+    Args:
+        v1 (float64[:, :]): it is a list of vector
+        v2 (float64[:, :]): It is a list of vector
+        result (float64[:, :]): this is the result array from host.
+    """
+    tid = cuda.threadIdx.x
+    Vec.vec3_sub(v1[tid, :], v2[tid, :], result[tid, :])
+
+
+@cuda.jit
+def vec3_norm_kernel(v: float64[:, :], result: float64[:]):
+    """ Unit test kernel function for vec3_norm_device
+
+    Args:
+        v (float64[:, :]): it is a list of vector
+        result (float64[:]): this is the result array from host.
+    """
+    tid = cuda.threadIdx.x
+    result[tid] = Vec.vec3_norm(v[tid, :])
+
+
+@cuda.jit
+def vec3_unit_kernel(v: float64[:, :], result: float64[:, :]):
+    """ Unit test kernel function for vec3_unit_device
+
+    Args:
+        v (float64[:, :]): it is a list of vector
+        result (float64[:, :]): this is the result array from host.
+    """
+    tid = cuda.threadIdx.x
+    Vec.vec3_unit(v[tid, :], result[tid, :])
+
+
+@cuda.jit
+def vec3_zero_kernel(result: float64[:, :]):
+    """ Unit test kernel function for vec3_zero_device
+
+    Args:
+        result (float64[:, :]): this is the result array from host.
+    """
+    tid = cuda.threadIdx.x
+    Vec.vec3_zero(result[tid, :])
+
+
+@cuda.jit
+def vec3_cross_kernel(v1: float64[:, :], v2: float64[:, :], result: float64[:, :]):
+    """ Unit test kernel function for vec3_cross_device
+
+    Args:
+        v1 (float64[:, :]): it is a list of vector
+        v2 (float64[:, :]): It is a list of vector
+        result (float64[:, :]): this is the result array from host.
+    """
+    tid = cuda.threadIdx.x
+    Vec.vec3_cross(v1[tid, :], v2[tid, :], result[tid, :])
+
+
+@cuda.jit
+def vec3_dot_kernel(v1: float64[:, :], v2: float64[:, :], result: float64[:]):
+    """ Unit test kernel function for vec3_dot_device
+
+    Args:
+        v1 (float64[:, :]): it is a list of vector
+        v2 (float64[:, :]): It is a list of vector
+        result (float64[:]): this is the result array from host.
+    """
+    tid = cuda.threadIdx.x
+    result[tid] = Vec.vec3_dot(v1[tid, :], v2[tid, :])
+
+
+@cuda.jit
+def vec3_mul_kernel(v: float64[:, :], s: float64, result: float64[:, :]):
+    """ Unit test kernel function for vec3_mul_device
+
+    Args:
+        v (float64[:, :]): it is a list of vector
+        s (float64): It is a scalar
+        result (float64[:, :]): this is the result array from host.
+    """
+    tid = cuda.threadIdx.x
+    Vec.vec3_mut_scalar(v[tid, :], s, result[tid, :])
+
+
+@cuda.jit
+def vec_argmin_kernel(v: float64[:, :], s: int32[:], result: int32[:]):
+    """ Unit test kernel function for vec_argmin_device
+
+    Args:
+        v (float64[:, :]): it is a list of vector.
+        s (int32[:]): It is a list of vector size or the number of elements to consider.
+        result (int32[:]): this is the result array from host.
+    """
+    tid = cuda.threadIdx.x
+    result[tid] = Vec.argmin(v[tid, :], s[tid])

--- a/python/rainbow/simulators/prox_soft_bodies/types.py
+++ b/python/rainbow/simulators/prox_soft_bodies/types.py
@@ -252,7 +252,7 @@ class Parameters:
             0.1  # Any geometry within this distance generates a contact point.
         )
         self.resolution = 64  # The number of grid cells along each axis in the signed distance fields.
-        self.use_gpu = True # Boolean flag that indicates if we should use the GPU or not.
+        self.use_gpu = False # Boolean flag that indicates if we should use the GPU or not.
         self.gpu_grid_size = 256 # The number of threads per block to use on the GPU.
 
 

--- a/python/rainbow/simulators/prox_soft_bodies/types.py
+++ b/python/rainbow/simulators/prox_soft_bodies/types.py
@@ -252,6 +252,8 @@ class Parameters:
             0.1  # Any geometry within this distance generates a contact point.
         )
         self.resolution = 64  # The number of grid cells along each axis in the signed distance fields.
+        self.use_gpu = True # Boolean flag that indicates if we should use the GPU or not.
+        self.gpu_grid_size = 256 # The number of threads per block to use on the GPU.
 
 
 class Engine:

--- a/python/unit_tests/test_cuda_geometry_barycentric.py
+++ b/python/unit_tests/test_cuda_geometry_barycentric.py
@@ -1,0 +1,47 @@
+import unittest
+import os
+import sys
+import numpy as np
+from numba import cuda
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import rainbow.util.test_tools as TEST
+import rainbow.geometry.grid3 as GRID
+import rainbow.cuda.unit_tests.test_geometry_barycentric_kernel as TEST_BCK
+
+
+class TestGrid3Cuda(unittest.TestCase):
+    
+    def test_compute_barycentric_tetrahedron(self):
+        x1_host = np.array([[1, 0, 0], [1, 0, 0]], dtype=np.float64)
+        x2_host = np.array([[0, 1, 0], [0, 1, 0]], dtype=np.float64)
+        x3_host = np.array([[0, 0, 1], [0, 0, 1]], dtype=np.float64)
+        x4_host = np.array([[0, 0, 0], [0, 0, 0]], dtype=np.float64)
+        u1 = np.array([0.1, -0.1])
+        u2 = np.array([0.1, -0.1])
+        u3 = np.array([0.1, -0.1])
+        p_host = []
+        expected = []
+        for i, _ in enumerate(u1):
+            u4 = 1 - u1[i] - u2[i] - u3[i]
+            p_host.append(u1[i]*x1_host[i] + u2[i]*x2_host[i] + u3[i]*x3_host[i] + u4*x4_host[i])
+            expected.append(np.array([u1[i], u2[i], u3[i], u4]))
+        p_host = np.array(p_host, dtype=np.float64)
+        expected = np.array(expected, dtype=np.float64)
+
+        x1_device = cuda.to_device(x1_host)
+        x2_device = cuda.to_device(x2_host)
+        x3_device = cuda.to_device(x3_host)
+        x4_device = cuda.to_device(x4_host)
+        p_device = cuda.to_device(p_host)
+
+        result_host = np.zeros((p_host.shape[0], 4), dtype=np.float64)
+        result_device = cuda.device_array_like(result_host)
+        TEST_BCK.compute_barycentric_tetrahedron_kernel[1, p_host.shape[0]](x1_device, x2_device, x3_device, x4_device, p_device, result_device)
+        result_device.copy_to_host(result_host)
+        self.assertTrue(TEST.is_array_equal(result_host, expected))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/unit_tests/test_cuda_geometry_barycentric.py
+++ b/python/unit_tests/test_cuda_geometry_barycentric.py
@@ -11,6 +11,7 @@ import rainbow.geometry.grid3 as GRID
 import rainbow.cuda.unit_tests.test_geometry_barycentric_kernel as TEST_BCK
 
 
+@unittest.skipIf(not cuda.is_available(), "CUDA not available")
 class TestGrid3Cuda(unittest.TestCase):
     
     def test_compute_barycentric_tetrahedron(self):

--- a/python/unit_tests/test_cuda_geometry_grid3.py
+++ b/python/unit_tests/test_cuda_geometry_grid3.py
@@ -11,6 +11,7 @@ import rainbow.geometry.grid3 as GRID
 import rainbow.cuda.unit_tests.test_geometry_grid3_kernel as TEST_GRID3K
 
 
+@unittest.skipIf(not cuda.is_available(), "CUDA not available")
 def simpelfunc(coord):
     _, _, z = coord[0], coord[1], coord[2]
     return z

--- a/python/unit_tests/test_cuda_geometry_grid3.py
+++ b/python/unit_tests/test_cuda_geometry_grid3.py
@@ -1,0 +1,221 @@
+import unittest
+import os
+import sys
+import numpy as np
+from numba import cuda
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import rainbow.util.test_tools as TEST
+import rainbow.geometry.grid3 as GRID
+import rainbow.cuda.unit_tests.test_geometry_grid3_kernel as TEST_GRID3K
+
+
+def simpelfunc(coord):
+    _, _, z = coord[0], coord[1], coord[2]
+    return z
+
+
+class TestGrid3Cuda(unittest.TestCase):
+
+    def setUp(self):
+        min_coord = np.array([-1, -1, -1])
+        max_coord = np.array([1, 1, 1])
+        I = 4
+        J = 4
+        K = 4
+
+        self.grid = GRID.Grid(min_coord, max_coord, I, J, K)
+    
+    def test_get_enclosing_cell_idx(self):
+        p_host = np.array([ [0, 0, 0],
+                            [-0.5, -0.5, -0.5],
+                            [0.5, 0.5, 0.5],
+                            [-1, -1, -1],
+                            [1, 1, 1],
+                            [-2, -2, -2],
+                            [2, 2, 2]], dtype=np.float64)
+        expected = np.array([[1, 1, 1],
+                                  [0, 0, 0],
+                                  [2, 2, 2],
+                                  [0, 0, 0],
+                                  [2, 2, 2],
+                                  [0, 0, 0],
+                                  [2, 2, 2]], dtype=np.int32)
+        min_coord_host = np.tile(self.grid.min_coord, p_host.shape)
+        spacing_host = np.tile(self.grid.spacing, p_host.shape)
+        I_host = np.repeat(self.grid.I, p_host.shape[0])
+        J_host = np.repeat(self.grid.J, p_host.shape[0])
+        K_host = np.repeat(self.grid.K, p_host.shape[0])
+        
+        p_device = cuda.to_device(p_host)
+        min_coord_device = cuda.to_device(min_coord_host)
+        spacing_device = cuda.to_device(spacing_host)
+        I_device = cuda.to_device(I_host)
+        J_device = cuda.to_device(J_host)
+        K_device = cuda.to_device(K_host)
+
+        result_host = np.zeros(p_host.shape, dtype=np.int32)
+        result_device = cuda.device_array_like(result_host)
+        TEST_GRID3K.get_enclosing_cell_idx_kernel[1,  p_host.shape[0]](p_device, min_coord_device, spacing_device, I_device, J_device, K_device, result_device)
+        result_device.copy_to_host(result_host)
+        self.assertTrue(TEST.is_array_equal(result_host, expected))
+
+    def test_get_node_value(self):
+        min_coord = np.array([-1, -1, -1])
+        max_coord = np.array([1, 1, 1])
+        I = 5
+        J = 5
+        K = 5
+        grid = GRID.Grid(min_coord, max_coord, I, J, K)
+        GRID.eval_on_grid(grid, simpelfunc)
+
+        i_host = np.array([0, 0])
+        j_host = np.array([0, 0])
+        k_host = np.array([4, 0])
+        values_host = np.tile(grid.values.reshape(1, -1), (i_host.shape[0], 1))
+        I_host = np.repeat(grid.I, i_host.shape[0])
+        J_host = np.repeat(grid.J, i_host.shape[0])
+        expected = np.array([1, -1], dtype=np.float64)
+
+        i_device = cuda.to_device(i_host)
+        j_device = cuda.to_device(j_host)
+        k_device = cuda.to_device(k_host)
+        values_device = cuda.to_device(values_host)
+        I_device = cuda.to_device(I_host)
+        J_device = cuda.to_device(J_host)
+
+        result_host = np.zeros((i_host.shape[0]), dtype=np.float64)
+        result_device = cuda.device_array_like(result_host)
+        TEST_GRID3K.get_node_value_kernel[1,  i_host.shape[0]](i_device, j_device, k_device, values_device, I_device, J_device, result_device)
+        result_device.copy_to_host(result_host)
+        self.assertTrue(TEST.is_array_equal(result_host, expected))
+
+    def test_get_value(self):
+
+        def func(p):
+            return p[0]
+        
+        min_coord = np.array([-1, -1, -1])
+        max_coord = np.array([1, 1, 1])
+        I = 5
+        J = 5
+        K = 5
+        grid = GRID.Grid(min_coord, max_coord, I, J, K)
+        GRID.eval_on_grid(grid, func)
+
+        p_host = np.array([ [0, 0, 0],
+                            [-0.5, -0.5, -0.5],
+                            [0.5, 0.5, 0.5],
+                            [-1, -1, -1],
+                            [1, 1, 1],
+                            [-2, -2, -2],
+                            [2, 2, 2]], dtype=np.float64)
+        expected = np.array([func(p_host[0]),
+                                  func(p_host[1]),
+                                  func(p_host[2]),
+                                  func(p_host[3]),
+                                  func(p_host[4]),
+                                  func(p_host[5]),
+                                  func(p_host[6])], dtype=np.float64)
+        min_coord_host = np.tile(grid.min_coord, p_host.shape)
+        spacing_host = np.tile(grid.spacing, p_host.shape)
+        I_host = np.repeat(grid.I, p_host.shape[0])
+        J_host = np.repeat(grid.J, p_host.shape[0])
+        K_host = np.repeat(grid.K, p_host.shape[0])
+        values_host = np.tile(grid.values.reshape(1, -1), (p_host.shape[0], 1))
+        p_device = cuda.to_device(p_host)
+        min_coord_device = cuda.to_device(min_coord_host)
+        spacing_device = cuda.to_device(spacing_host)
+        I_device = cuda.to_device(I_host)
+        J_device = cuda.to_device(J_host)
+        K_device = cuda.to_device(K_host)
+        values_device = cuda.to_device(values_host)
+
+        result_host = np.zeros(p_host.shape[0], dtype=np.float64)
+        result_device = cuda.device_array_like(result_host)
+        TEST_GRID3K.get_value_kernel[1,  p_host.shape[0]](p_device, min_coord_device, spacing_device, I_device, J_device, K_device, values_device, result_device)
+        result_device.copy_to_host(result_host)
+        for res, exp in zip(result_host, expected):
+            self.assertAlmostEqual(res, exp)
+
+    def test_is_inside(self):
+        p_host = np.array([ [-1, -1, -1],
+                            [0, 0, 0],
+                            [1, 1, 1],
+                            [-1.1, -1.1, -1.1],
+                            [1.1, 1.1, 1.1],
+                            [-1, -1, -1],
+                            [0, 0, 0],
+                            [1, 1, 1],
+                            [-1.1, -1.1, -1.1],
+                            [1.1, 1.1, 1.1]], dtype=np.float64)
+        boundary_host = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.5, 0.5, 0.5, 0.5, 0.5], dtype=np.float64)
+        min_coord_host = np.tile(self.grid.min_coord, p_host.shape)
+        max_coord_host = np.tile(self.grid.max_coord, p_host.shape)
+        expected = np.array([True, True, True, False, False, False, True, False, False, False], dtype=bool)
+
+        p_device = cuda.to_device(p_host)
+        boundary_device = cuda.to_device(boundary_host)
+        min_coord_device = cuda.to_device(min_coord_host)
+        max_coord_device = cuda.to_device(max_coord_host)
+
+        result_host = np.zeros(p_host.shape[0], dtype=bool)
+        result_device = cuda.device_array_like(result_host)
+        TEST_GRID3K.is_inside_kernel[1,  p_host.shape[0]](p_device, min_coord_device, max_coord_device, boundary_device, result_device)
+        result_device.copy_to_host(result_host)
+        self.assertTrue(TEST.is_array_equal(result_host, expected))
+    
+    def test_get_gradient(self):
+        def func(p):
+            return p[0]
+
+        def grad(p):
+            return np.array([1, 0, 0])
+        
+        min_coord = np.array([-1, -1, -1])
+        max_coord = np.array([1, 1, 1])
+        I = 5
+        J = 5
+        K = 5
+        grid = GRID.Grid(min_coord, max_coord, I, J, K)
+        GRID.eval_on_grid(grid, func)
+
+        p_host = np.array([ [0, 0, 0],
+                            [-0.5, -0.5, -0.5],
+                            [0.5, 0.5, 0.5],
+                            [-1, -1, -1],
+                            [1, 1, 1],
+                            [-2, -2, -2],
+                            [2, 2, 2]], dtype=np.float64)
+        expected = np.array([ grad(p_host[0]),
+                              grad(p_host[1]),
+                              grad(p_host[2]),
+                              grad(p_host[3]),
+                              grad(p_host[4]),
+                              grad(p_host[5]),
+                              grad(p_host[6])], dtype=np.float64)
+        min_coord_host = np.tile(grid.min_coord, p_host.shape)
+        spacing_host = np.tile(grid.spacing, p_host.shape)
+        I_host = np.repeat(grid.I, p_host.shape[0])
+        J_host = np.repeat(grid.J, p_host.shape[0])
+        K_host = np.repeat(grid.K, p_host.shape[0])
+        values_host = np.tile(grid.values.reshape(1, -1), (p_host.shape[0], 1))
+
+        p_device = cuda.to_device(p_host)
+        min_coord_device = cuda.to_device(min_coord_host)
+        spacing_device = cuda.to_device(spacing_host)
+        I_device = cuda.to_device(I_host)
+        J_device = cuda.to_device(J_host)
+        K_device = cuda.to_device(K_host)
+        values_device = cuda.to_device(values_host)
+
+        result_host = np.zeros(p_host.shape, dtype=np.float64)
+        result_device = cuda.device_array_like(result_host)
+        TEST_GRID3K.get_gradient_kernel[1,  p_host.shape[0]](p_device, min_coord_device, spacing_device, I_device, J_device, K_device, values_device, result_device)
+        result_device.copy_to_host(result_host)
+        self.assertTrue(TEST.is_array_equal(result_host, expected))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/unit_tests/test_cuda_geometry_grid3.py
+++ b/python/unit_tests/test_cuda_geometry_grid3.py
@@ -11,10 +11,10 @@ import rainbow.geometry.grid3 as GRID
 import rainbow.cuda.unit_tests.test_geometry_grid3_kernel as TEST_GRID3K
 
 
-
 def simpelfunc(coord):
     _, _, z = coord[0], coord[1], coord[2]
     return z
+
 
 @unittest.skipIf(not cuda.is_available(), "CUDA not available")
 class TestGrid3Cuda(unittest.TestCase):

--- a/python/unit_tests/test_cuda_geometry_grid3.py
+++ b/python/unit_tests/test_cuda_geometry_grid3.py
@@ -11,12 +11,12 @@ import rainbow.geometry.grid3 as GRID
 import rainbow.cuda.unit_tests.test_geometry_grid3_kernel as TEST_GRID3K
 
 
-@unittest.skipIf(not cuda.is_available(), "CUDA not available")
+
 def simpelfunc(coord):
     _, _, z = coord[0], coord[1], coord[2]
     return z
 
-
+@unittest.skipIf(not cuda.is_available(), "CUDA not available")
 class TestGrid3Cuda(unittest.TestCase):
 
     def setUp(self):

--- a/python/unit_tests/test_cuda_math_linalg.py
+++ b/python/unit_tests/test_cuda_math_linalg.py
@@ -1,0 +1,32 @@
+import unittest
+import os
+import sys
+import numpy as np
+from numba import cuda
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import rainbow.cuda.unit_tests.test_math_linalg_kernel as TEST_LinAlgK
+import rainbow.util.test_tools as TEST
+
+
+class TestLinAlgCuda(unittest.TestCase):
+    
+    def test_cramer_solver(self):
+        A_host = np.array([[[1.0, 2.0, 3.0],
+                            [4.0, 5.0, 6.0],
+                            [7.0, 8.0, 9.0]]], dtype=np.float64)
+        b_host = np.array([[1.0, 2.0, 3.0]], dtype=np.float64)
+        expected = np.array([[-0.0, 0.0, 0.0]], dtype=np.float64)
+        result_host = np.zeros((1, 3), dtype=np.float64)
+        A_device = cuda.to_device(A_host)
+        b_device = cuda.to_device(b_host)
+        result_device = cuda.device_array_like(result_host)
+        TEST_LinAlgK.cramer_solver_kernel[1, 1](
+            A_device, b_device, result_device)
+        result_device.copy_to_host(result_host)
+        self.assertTrue(TEST.is_array_equal(result_host, expected))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/unit_tests/test_cuda_math_linalg.py
+++ b/python/unit_tests/test_cuda_math_linalg.py
@@ -10,6 +10,7 @@ import rainbow.cuda.unit_tests.test_math_linalg_kernel as TEST_LinAlgK
 import rainbow.util.test_tools as TEST
 
 
+@unittest.skipIf(not cuda.is_available(), "CUDA not available")
 class TestLinAlgCuda(unittest.TestCase):
     
     def test_cramer_solver(self):

--- a/python/unit_tests/test_cuda_math_matrix.py
+++ b/python/unit_tests/test_cuda_math_matrix.py
@@ -1,0 +1,130 @@
+import unittest
+import os
+import sys
+import numpy as np
+from numba import cuda
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import rainbow.util.test_tools as TEST
+import rainbow.cuda.unit_tests.test_math_matrix_kernel as TEST_MK
+
+
+class TestMatrixCuda(unittest.TestCase):
+    
+    def test_mat33_T(self):
+        m_host = np.array([[[1.0, 2.0, 3.0],
+                           [4.0, 5.0, 6.0],
+                           [7.0, 8.0, 9.0]]], dtype=np.float64)
+        expected = np.array([[[1.0, 4.0, 7.0],
+                             [2.0, 5.0, 8.0],
+                             [3.0, 6.0, 9.0]]], dtype=np.float64)
+        result_host = np.zeros((1, 3, 3), dtype=np.float64)
+        m_device = cuda.to_device(m_host)
+        result_device = cuda.device_array_like(result_host)
+        TEST_MK.mat33_T_kernel[1, 1](m_device, result_device)
+        result_device.copy_to_host(result_host)
+        self.assertTrue(TEST.is_array_equal(result_host, expected))
+
+    def test_mat33_zero(self):
+        expected = np.array([[[0.0, 0.0, 0.0],
+                             [0.0, 0.0, 0.0],
+                             [0.0, 0.0, 0.0]]], dtype=np.float64)
+        result_host = np.zeros((1, 3, 3), dtype=np.float64)
+        result_device = cuda.device_array_like(result_host)
+        TEST_MK.mat33_zero_kernel[1, 1](result_device)
+        result_device.copy_to_host(result_host)
+        self.assertTrue(TEST.is_array_equal(result_host, expected))
+
+    def test_mat33_determinant(self):
+        m_host = np.array([[[1.0, 2.0, 3.0],
+                           [4.0, 5.0, 6.0],
+                           [7.0, 8.0, 9.0]]], dtype=np.float64)
+        expected = np.array([-0.0], dtype=np.float64)
+        result_host = np.zeros((1), dtype=np.float64)
+        m_device = cuda.to_device(m_host)
+        result_device = cuda.device_array_like(result_host)
+        TEST_MK.mat33_determinant_kernel[1, 1](m_device, result_device)
+        result_device.copy_to_host(result_host)
+        self.assertTrue(TEST.is_array_equal(result_host, expected))
+
+    def test_mat33_make(self):
+        expected = np.array([[[1.0, 2.0, 3.0],
+                             [4.0, 5.0, 6.0],
+                             [7.0, 8.0, 9.0]]], dtype=np.float64)
+        result_host = np.zeros((1, 3, 3), dtype=np.float64)
+        result_device = cuda.device_array_like(result_host)
+        TEST_MK.mat33_make_kernel[1, 1](np.array([1.0]), np.array([2.0]), np.array([3.0]),
+                                        np.array([4.0]), np.array(
+                                            [5.0]), np.array([6.0]),
+                                        np.array([7.0]), np.array(
+                                            [8.0]), np.array([9.0]),
+                                        result_device)
+        result_device.copy_to_host(result_host)
+        self.assertTrue(TEST.is_array_equal(result_host, expected))
+
+    def test_mat33_make_from_cols(self):
+        col0_host = np.array([[1.0, 4.0, 7.0]], dtype=np.float64)
+        col1_host = np.array([[2.0, 5.0, 8.0]], dtype=np.float64)
+        col2_host = np.array([[3.0, 6.0, 9.0]], dtype=np.float64)
+        expected = np.array([[[1.0, 2.0, 3.0],
+                             [4.0, 5.0, 6.0],
+                             [7.0, 8.0, 9.0]]], dtype=np.float64)
+        result_host = np.zeros((1, 3, 3), dtype=np.float64)
+        col0_device = cuda.to_device(col0_host)
+        col1_device = cuda.to_device(col1_host)
+        col2_device = cuda.to_device(col2_host)
+        result_device = cuda.device_array_like(result_host)
+        TEST_MK.mat33_make_from_cols_kernel[1, 1](
+            col0_device, col1_device, col2_device, result_device)
+        result_device.copy_to_host(result_host)
+        self.assertTrue(TEST.is_array_equal(result_host, expected))
+
+    def test_mat33_dot_vec3(self):
+        m_host = np.array([[[1.0, 2.0, 3.0],
+                           [4.0, 5.0, 6.0],
+                           [7.0, 8.0, 9.0]]], dtype=np.float64)
+        vec3_host = np.array([[1.0, 2.0, 3.0]], dtype=np.float64)
+        expected = np.array([[14.0, 32.0, 50.0]], dtype=np.float64)
+        result_host = np.zeros((1, 3), dtype=np.float64)
+        m_device = cuda.to_device(m_host)
+        vec3_device = cuda.to_device(vec3_host)
+        result_device = cuda.device_array_like(result_host)
+        TEST_MK.mat33_dot_vec3_kernel[1, 1](
+            m_device, vec3_device, result_device)
+        result_device.copy_to_host(result_host)
+        self.assertTrue(TEST.is_array_equal(result_host, expected))
+
+    def test_mat43_T(self):
+        m_host = np.array([[[1.0, 5.0, 9.0],
+                            [2.0, 6.0, 10.0],
+                            [3.0, 7.0, 11.0],
+                            [4.0, 8.0, 12.0]]], dtype=np.float64)
+        expected = np.array([[[1.0, 2.0, 3.0, 4.0],
+                              [5.0, 6.0, 7.0, 8.0],
+                              [9.0, 10.0, 11.0, 12.0]]], dtype=np.float64)
+        result_host = np.zeros((1, 3, 4), dtype=np.float64)
+        m_device = cuda.to_device(m_host)
+        result_device = cuda.device_array_like(result_host)
+        TEST_MK.mat43_T_kernel[1, 1](m_device, result_device)
+        result_device.copy_to_host(result_host)
+        self.assertTrue(TEST.is_array_equal(result_host, expected))
+
+    def test_mat34_dot_vec4(self):
+        m_host = np.array([[[1.0, 2.0, 3.0, 4.0],
+                            [5.0, 6.0, 7.0, 8.0],
+                            [9.0, 10.0, 11.0, 12.0]]], dtype=np.float64)
+        vec4_host = np.array([[1.0, 2.0, 3.0, 4.0]], dtype=np.float64)
+        expected = np.array([[30.0, 70.0, 110.0]], dtype=np.float64)
+        result_host = np.zeros((1, 3), dtype=np.float64)
+        m_device = cuda.to_device(m_host)
+        vec4_device = cuda.to_device(vec4_host)
+        result_device = cuda.device_array_like(result_host)
+        TEST_MK.mat34_dot_vec4_kernel[1, 1](
+            m_device, vec4_device, result_device)
+        result_device.copy_to_host(result_host)
+        self.assertTrue(TEST.is_array_equal(result_host, expected))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/unit_tests/test_cuda_math_matrix.py
+++ b/python/unit_tests/test_cuda_math_matrix.py
@@ -10,6 +10,7 @@ import rainbow.util.test_tools as TEST
 import rainbow.cuda.unit_tests.test_math_matrix_kernel as TEST_MK
 
 
+@unittest.skipIf(not cuda.is_available(), "CUDA not available")
 class TestMatrixCuda(unittest.TestCase):
     
     def test_mat33_T(self):

--- a/python/unit_tests/test_cuda_math_vec.py
+++ b/python/unit_tests/test_cuda_math_vec.py
@@ -10,6 +10,7 @@ import rainbow.cuda.unit_tests.test_math_vec_kernel as TEST_VK
 import rainbow.util.test_tools as TEST
 
 
+@unittest.skipIf(not cuda.is_available(), "CUDA not available")
 class TestVec3Cuda(unittest.TestCase):
     
     def test_vec3_add(self):

--- a/python/unit_tests/test_cuda_math_vec.py
+++ b/python/unit_tests/test_cuda_math_vec.py
@@ -1,0 +1,96 @@
+import unittest
+import os
+import sys
+import numpy as np
+from numba import cuda
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import rainbow.cuda.unit_tests.test_math_vec_kernel as TEST_VK
+import rainbow.util.test_tools as TEST
+
+
+class TestVec3Cuda(unittest.TestCase):
+    
+    def test_vec3_add(self):
+        v1_host = np.array([[1.0, 2.0, 3.0]], dtype=np.float64)
+        v2_host = np.array([[4.0, 5.0, 6.0]], dtype=np.float64)
+        expected = np.array([[5.0, 7.0, 9.0]], dtype=np.float64)
+        result_host = np.zeros((1, 3), dtype=np.float64)
+        v1_device = cuda.to_device(v1_host)
+        v2_device = cuda.to_device(v2_host)
+        result_device = cuda.device_array_like(result_host)
+        TEST_VK.vec3_add_kernel[1, 1](v1_device, v2_device, result_device)
+        result_device.copy_to_host(result_host)
+        self.assertTrue(TEST.is_array_equal(result_host, expected))
+    
+    def test_vec3_sub(self):
+        v1_host = np.array([[1.0, 2.0, 3.0]], dtype=np.float64)
+        v2_host = np.array([[4.0, 5.0, 6.0]], dtype=np.float64)
+        expected = np.array([[-3.0, -3.0, -3.0]], dtype=np.float64)
+        result_host = np.zeros((1, 3), dtype=np.float64)
+        v1_device = cuda.to_device(v1_host)
+        v2_device = cuda.to_device(v2_host)
+        result_device = cuda.device_array_like(result_host)
+        TEST_VK.vec3_sub_kernel[1, 1](v1_device, v2_device, result_device)
+        result_device.copy_to_host(result_host)
+        self.assertTrue(TEST.is_array_equal(result_host, expected))
+    
+    def test_vec3_norm(self):
+        v_host = np.array([[1.0, 0.0, 0.0]], dtype=np.float64)
+        expected = np.array([1.0], dtype=np.float64)
+        result_host = np.zeros((1), dtype=np.float64)
+        v_device = cuda.to_device(v_host)
+        result_device = cuda.device_array_like(result_host)
+        TEST_VK.vec3_norm_kernel[1, 1](v_device, result_device)
+        result_device.copy_to_host(result_host)
+        self.assertTrue(TEST.is_array_equal(result_host, expected))
+    
+    def test_vec3_dot(self):
+        v1_host = np.array([[1.0, 0.0, 0.0]], dtype=np.float64)
+        v2_host = np.array([[0.0, 1.0, 0.0]], dtype=np.float64)
+        expected = np.array([0.0], dtype=np.float64)
+        result_host = np.zeros((1), dtype=np.float64)
+        v1_device = cuda.to_device(v1_host)
+        v2_device = cuda.to_device(v2_host)
+        result_device = cuda.device_array_like(result_host)
+        TEST_VK.vec3_dot_kernel[1, 1](v1_device, v2_device, result_device)
+        result_device.copy_to_host(result_host)
+        self.assertTrue(TEST.is_array_equal(result_host, expected))
+    
+    def test_vec3_cross(self):
+        v1_host = np.array([[1.0, 0.0, 0.0]], dtype=np.float64)
+        v2_host = np.array([[0.0, 1.0, 0.0]], dtype=np.float64)
+        expected = np.array([[0.0, 0.0, 1.0]], dtype=np.float64)
+        result_host = np.zeros((1, 3), dtype=np.float64)
+        v1_device = cuda.to_device(v1_host)
+        v2_device = cuda.to_device(v2_host)
+        result_device = cuda.device_array_like(result_host)
+        TEST_VK.vec3_cross_kernel[1, 1](v1_device, v2_device, result_device)
+        result_device.copy_to_host(result_host)
+        self.assertTrue(TEST.is_array_equal(result_host, expected))
+    
+    def test_vec3_mul(self):
+        v_host = np.array([[1.0, 2.0, 3.0]], dtype=np.float64)
+        expected = np.array([[2.0, 4.0, 6.0]], dtype=np.float64)
+        result_host = np.zeros((1, 3), dtype=np.float64)
+        v_device = cuda.to_device(v_host)
+        result_device = cuda.device_array_like(result_host)
+        TEST_VK.vec3_mul_kernel[1, 1](v_device, 2.0, result_device)
+        result_device.copy_to_host(result_host)
+        self.assertTrue(TEST.is_array_equal(result_host, expected))
+
+    def test_vec_argmin(self):
+        v_host = np.array([[1.0, 2.0, 3.0]], dtype=np.float64)
+        s_host = np.array([3])
+        expected = np.array([0], dtype=np.float64)
+        result_host = np.zeros((1), dtype=np.float64)
+        v_device = cuda.to_device(v_host)
+        s_device = cuda.to_device(s_host)
+        result_device = cuda.device_array_like(result_host)
+        TEST_VK.vec_argmin_kernel[1, 1](v_device, s_device, result_device)
+        result_device.copy_to_host(result_host)
+        self.assertTrue(TEST.is_array_equal(result_host, expected))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/unit_tests/test_cuda_math_vec.py
+++ b/python/unit_tests/test_cuda_math_vec.py
@@ -92,5 +92,6 @@ class TestVec3Cuda(unittest.TestCase):
         result_device.copy_to_host(result_host)
         self.assertTrue(TEST.is_array_equal(result_host, expected))
 
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Parallel computing the contact point on GPU. 

Updates:
1. We wrote a lot of device functions in the `python/rainbow/cuda` folder, and the contact point computing kernel function in `python/rainbow/cuda/collision_detection/compute_contacts.py'. 
2. On the host file, we add a new contact point computing function, which is used for executing the kernel function to speed up.
3. We also write a lot of unit test kernel functions, which are located in the `python/rainbow/cuda/unit/` folder, and the unit test host files are located in the `python/unit_tests` folder.
4. It will compute on the CPU when the machine does not support CUDA, and there is a flag variable to control the computing on GPU or not, the default value of it is False.

Environment Requirments:
-  CUDA toolkit
-  Numba
