### PR TITLE
Bugfix/assert array equal

### DIFF
--- a/python/rainbow/util/test_tools.py
+++ b/python/rainbow/util/test_tools.py
@@ -6,7 +6,7 @@ concerned with making it convenient to test array-like data types.
 """
 
 
-def is_array_equal(arr1, arr2, dec=8):
+def is_array_equal(arr1, arr2):
     """
     2022-04-06 Kenny TODO: Write proper documentation.
 
@@ -15,7 +15,7 @@ def is_array_equal(arr1, arr2, dec=8):
     :param dec:
     :return:
     """
-    return None == np.testing.assert_array_almost_equal(arr1, arr2, dec)
+    return None == np.testing.assert_allclose(arr1, arr2, rtol=1e-5, atol=1e-8)
 
 
 def is_array_not_equal(arr1, arr2):

--- a/python/rainbow/util/test_tools.py
+++ b/python/rainbow/util/test_tools.py
@@ -8,12 +8,12 @@ concerned with making it convenient to test array-like data types.
 
 def is_array_equal(arr1, arr2, dec=8):
     """
-    2022-04-06 Kenny TODO: Write proper documentation.
+    Checks if two arrays are almost equal by comparing each element up to a specified decimal place.
 
-    :param arr1:
-    :param arr2:
-    :param dec:
-    :return:
+    :param arr1: First input array to compare.
+    :param arr2: Second input array to compare against the first array.
+    :param dec: The desired precision in decimal places. Default is 8.
+    :return: True if the arrays are almost equal, False otherwise.
     """
     return None == np.testing.assert_allclose(arr1, arr2, rtol=10**-dec, atol=10**-dec)
 

--- a/python/rainbow/util/test_tools.py
+++ b/python/rainbow/util/test_tools.py
@@ -6,7 +6,7 @@ concerned with making it convenient to test array-like data types.
 """
 
 
-def is_array_equal(arr1, arr2):
+def is_array_equal(arr1, arr2, dec=8):
     """
     2022-04-06 Kenny TODO: Write proper documentation.
 
@@ -15,7 +15,7 @@ def is_array_equal(arr1, arr2):
     :param dec:
     :return:
     """
-    return None == np.testing.assert_allclose(arr1, arr2, rtol=1e-5, atol=1e-8)
+    return None == np.testing.assert_allclose(arr1, arr2, rtol=10**-dec, atol=10**-dec)
 
 
 def is_array_not_equal(arr1, arr2):


### PR DESCRIPTION
I found that the GitHub auto-test error occurs sometimes in the Windows system, that because of using the `np.testing.assert_array_almost_equal`. 
Now, `np.testing.allclose` is used to fix this problem by the Numpy official advice, more information refers to https://numpy.org/doc/stable/reference/generated/numpy.testing.assert_array_almost_equal.html